### PR TITLE
Update Suggestion

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -42,11 +42,12 @@ void Config::load(size_t id) noexcept
     if (!in.good())
         return;
 	int checkver = 0;
-	ArchiveX<std::ifstream>{ in } >> checkver;
+	ArchiveX<std::ifstream>{ in } >> checkver >> triggerbot >> backtrack >> glow >> chams >> esp >> visuals >> knifeChanger >> misc;
 	if (checkver == version) {
-		ArchiveX<std::ifstream>{ in } >> aimbot >> triggerbot >> backtrack >> glow >> chams >> esp >> visuals >> knifeChanger >> misc;
+		ArchiveX<std::ifstream>{ in } >> version >> aimbot >> triggerbot >> backtrack >> glow >> chams >> esp >> visuals >> knifeChanger >> misc;
 	}
 	else {
+		reset();
 		interfaces.gameUI->messageBox("Config", "Config cannot be loaded due to version mismatch");
 	}
 	in.close();

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -1,9 +1,14 @@
 #include <fstream>
 #include <ShlObj.h>
-
+#include "Interfaces.h"
 #include "ArchiveX.h"
+#include <string>
 
 #include "Config.h"
+#include "SDK/Panel.h"
+#include "SDK/InputSystem.h"
+#include "SDK/GameUI.h"
+#include "SDK/Surface.h"
 
 Config::Config(const char* name) noexcept
 {
@@ -36,9 +41,16 @@ void Config::load(size_t id) noexcept
 
     if (!in.good())
         return;
+	int checkver = 0;
+	ArchiveX<std::ifstream>{ in } >> checkver;
+	if (checkver == version) {
+		ArchiveX<std::ifstream>{ in } >> aimbot >> triggerbot >> backtrack >> glow >> chams >> esp >> visuals >> knifeChanger >> misc;
+	}
+	else {
+		interfaces.gameUI->messageBox("Config", "Config cannot be loaded due to version mismatch");
+	}
+	in.close();
 
-    ArchiveX<std::ifstream>{ in } >> aimbot >> triggerbot >> backtrack >> glow >> chams >> esp >> visuals >> knifeChanger >> misc;
-    in.close();
 }
 
 void Config::save(size_t id) const noexcept
@@ -53,7 +65,7 @@ void Config::save(size_t id) const noexcept
     if (!out.good())
         return;
 
-    ArchiveX<std::ofstream>{ out } << aimbot << triggerbot << backtrack << glow << chams << esp << visuals << knifeChanger << misc;
+    ArchiveX<std::ofstream>{ out } << version << aimbot << triggerbot << backtrack << glow << chams << esp << visuals << knifeChanger << misc;
     out.close();
 }
 

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -42,7 +42,7 @@ void Config::load(size_t id) noexcept
     if (!in.good())
         return;
 	int checkver = 0;
-	ArchiveX<std::ifstream>{ in } >> checkver >> triggerbot >> backtrack >> glow >> chams >> esp >> visuals >> knifeChanger >> misc;
+	ArchiveX<std::ifstream>{ in } >> checkver >> aimbot >> triggerbot >> backtrack >> glow >> chams >> esp >> visuals >> knifeChanger >> misc;
 	if (checkver == version) {
 		ArchiveX<std::ifstream>{ in } >> version >> aimbot >> triggerbot >> backtrack >> glow >> chams >> esp >> visuals >> knifeChanger >> misc;
 	}

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -11,7 +11,7 @@ public:
     void remove(size_t) noexcept;
     void rename(size_t, const char*) noexcept;
     void reset() noexcept;
-	int version = 1;
+	int version = 2;
 
     constexpr auto& getConfigs() noexcept
     {

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -35,8 +35,11 @@ public:
             bool ignoreSmoke{ false };
             bool autoShot{ false };
             bool recoilbasedFov{ false };
+			bool fovslider{ false };
             float fov{ 0.0f };
+			bool maxAngleDeltaslider{ false };
             float maxAngleDelta{ 0.0f };
+			bool smoothslider{ false };
             float smooth{ 1.0f };
             int bone{ 0 };
             float recoilControlX{ 0.0f };

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -11,6 +11,7 @@ public:
     void remove(size_t) noexcept;
     void rename(size_t, const char*) noexcept;
     void reset() noexcept;
+	int version = 1;
 
     constexpr auto& getConfigs() noexcept
     {

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -144,6 +144,7 @@ public:
         float brightness{ 0.0f };
         int skybox{ -1 };
         float worldColor[3]{ 0.0f, 0.0f, 0.0f };
+		bool rainbowWorld{ false };
     } visuals;
 
     struct {

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -245,7 +245,7 @@ void GUI::renderBacktrackWindow() noexcept
         ImGui::Checkbox("Enabled", &config.backtrack.enabled);
         ImGui::Checkbox("Ignore smoke", &config.backtrack.ignoreSmoke);
         ImGui::PushItemWidth(220.0f);
-        ImGui::SliderInt("", &config.backtrack.timeLimit, 1, 2000, "Time limit: %d ms");
+        ImGui::SliderInt("", &config.backtrack.timeLimit, 1, 200, "Time limit: %d ms");
         ImGui::PopItemWidth();
         ImGui::End();
     }

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -402,6 +402,7 @@ void GUI::renderVisualsWindow() noexcept
         ImGui::PopItemWidth();
         ImGui::Combo("Skybox", &config.visuals.skybox, "cs_baggage_skybox_\0cs_tibet\0embassy\0italy\0jungle\0nukeblank\0office\0sky_cs15_daylight01_hdr\0sky_cs15_daylight02_hdr\0sky_cs15_daylight03_hdr\0sky_cs15_daylight04_hdr\0sky_csgo_cloudy01\0sky_csgo_night_flat\0sky_csgo_night02\0sky_day02_05_hdr\0sky_day02_05\0sky_dust\0sky_l4d_rural02_ldr\0sky_venice\0vertigo_hdr\0vertigo\0vertigoblue_hdr\0vietnam\0");
         ImGui::ColorEdit3("World color", config.visuals.worldColor, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoTooltip);
+		ImGui::Checkbox("Rainbow World [70457Y]", &config.visuals.rainbowWorld);
         ImGui::End();
     }
 }

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -88,7 +88,7 @@ void GUI::renderMenuBar() noexcept
 void GUI::renderAimbotWindow() noexcept
 {
     if (window.aimbot) {
-        ImGui::SetNextWindowSize({ 260.0f, 475.0f });
+        ImGui::SetNextWindowSize({ 0.0f, 0.0f });
         ImGui::Begin("Aimbot", &window.aimbot, windowFlags);
         static int currentCategory{ 0 };
         ImGui::PushItemWidth(110.0f);
@@ -184,7 +184,7 @@ void GUI::renderAimbotWindow() noexcept
 void GUI::renderTriggerbotWindow() noexcept
 {
     if (window.triggerbot) {
-        ImGui::SetNextWindowSize({ 250.0f, 270.0f });
+        ImGui::SetNextWindowSize({ 0.0f, 0.0f });
         ImGui::Begin("Triggerbot", &window.triggerbot, windowFlags);
         static int currentCategory{ 0 };
         ImGui::PushItemWidth(110.0f);
@@ -244,7 +244,7 @@ void GUI::renderTriggerbotWindow() noexcept
 void GUI::renderBacktrackWindow() noexcept
 {
     if (window.backtrack) {
-        ImGui::SetNextWindowSize({ 260.f, 125.f });
+        ImGui::SetNextWindowSize({ 0.f, 0.f });
         ImGui::Begin("Backtrack", &window.backtrack, windowFlags);
         ImGui::Checkbox("Enabled", &config.backtrack.enabled);
         ImGui::Checkbox("Ignore smoke", &config.backtrack.ignoreSmoke);
@@ -258,7 +258,7 @@ void GUI::renderBacktrackWindow() noexcept
 void GUI::renderGlowWindow() noexcept
 {
     if (window.glow) {
-        ImGui::SetNextWindowSize({ 250.0f, 245.0f });
+        ImGui::SetNextWindowSize({ 0.0f, 0.0f });
         ImGui::Begin("Glow", &window.glow, windowFlags);
         static int currentCategory{ 0 };
         ImGui::PushItemWidth(110.0f);
@@ -311,7 +311,7 @@ void GUI::renderGlowWindow() noexcept
 void GUI::renderChamsWindow() noexcept
 {
     if (window.chams) {
-        ImGui::SetNextWindowSize({ 250.0f, 245.0f });
+        ImGui::SetNextWindowSize({ 0.0f, 0.0f });
         ImGui::Begin("Chams", &window.chams, windowFlags);
         static int currentCategory{ 0 };
         ImGui::PushItemWidth(110.0f);
@@ -362,7 +362,7 @@ void GUI::renderChamsWindow() noexcept
 void GUI::renderEspWindow() noexcept
 {
     if (window.esp) {
-        ImGui::SetNextWindowSize({ 250.0f, 190.0f });
+        ImGui::SetNextWindowSize({ 0.0f, 0.0f });
         ImGui::Begin("Esp", &window.esp, windowFlags);
         static int currentCategory{ 0 };
         ImGui::PushItemWidth(110.0f);
@@ -387,7 +387,7 @@ void GUI::renderEspWindow() noexcept
 void GUI::renderVisualsWindow() noexcept
 {
     if (window.visuals) {
-        ImGui::SetNextWindowSize({ 520.0f, 365.0f });
+        ImGui::SetNextWindowSize({ 0.0f, 0.0f });
         ImGui::Begin("Visuals", &window.visuals, windowFlags);
         ImGui::Columns(2, nullptr, false);
         ImGui::SetColumnOffset(1, 210.0f);
@@ -432,7 +432,7 @@ void GUI::renderVisualsWindow() noexcept
 void GUI::renderKnifeChangerWindow() noexcept
 {
     if (window.knifeChanger) {
-        ImGui::SetNextWindowSize({ 180.0f, 100.0f });
+        ImGui::SetNextWindowSize({ 0.0f, 0.0f });
         ImGui::Begin("Knife changer", &window.knifeChanger, windowFlags);
         ImGui::PushItemWidth(130.0f);
         ImGui::Checkbox("Enabled", &config.knifeChanger.enabled);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -74,7 +74,7 @@ void GUI::renderMenuBar() noexcept
         ImGui::MenuItem("Esp", nullptr, &window.esp);
         ImGui::MenuItem("Visuals", nullptr, &window.visuals);
         ImGui::MenuItem("Knife changer", nullptr, &window.knifeChanger);
-        // ImGui::MenuItem("Skin changer", nullptr, &window.skinChanger);
+        ImGui::MenuItem("Skin changer", nullptr, &window.skinChanger);
         ImGui::MenuItem("Misc", nullptr, &window.misc);
         ImGui::MenuItem("Config", nullptr, &window.config);
         ImGui::EndMainMenuBar();
@@ -160,11 +160,11 @@ void GUI::renderAimbotWindow() noexcept
         ImGui::PopID();
         ImGui::PushID(7);
 		ImGui::Checkbox("Small Smooth Slider", &config.aimbot[currentWeapon].smoothslider);
-		if (config.aimbot[currentWeapon].maxAngleDeltaslider) {
-			ImGui::SliderFloat("", &config.aimbot[currentWeapon].smooth, 0.0f, 15.0f, "Smooth: %.2f");
+		if (config.aimbot[currentWeapon].smoothslider) {
+			ImGui::SliderFloat("", &config.aimbot[currentWeapon].smooth, 1.0f, 15.0f, "Smooth: %.2f");
 		}
 		else {
-			ImGui::SliderFloat("", &config.aimbot[currentWeapon].smooth, 0.0f, 100.0f, "Smooth: %.2f");
+			ImGui::SliderFloat("", &config.aimbot[currentWeapon].smooth, 1.0f, 100.0f, "Smooth: %.2f");
 		}
         ImGui::PopID();
         ImGui::PushID(8);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -1,7 +1,10 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <string>
 #include <Windows.h>
-#include<stdlib.h>
+#include <stdlib.h>
+#include <sstream>
+#include <iostream>
+
 
 #include "imgui/imgui.h"
 #include "GUI.h"
@@ -501,7 +504,6 @@ void GUI::renderMiscWindow() noexcept
         ImGui::Text("Menu key");
         ImGui::SameLine();
         hotkey(config.misc.menuKey);
-		ImGui::Text(std::to_string(config.version).c_str());
         ImGui::Checkbox("Auto strafe", &config.misc.autoStrafe);
         ImGui::Checkbox("Bunny hop", &config.misc.bunnyHop);
         static char buffer[16];
@@ -537,8 +539,9 @@ void GUI::renderMiscWindow() noexcept
 void GUI::renderConfigWindow() noexcept
 {
     if (window.config) {
-        ImGui::SetNextWindowSize({ 290.0f, 190.0f });
+        ImGui::SetNextWindowSize({ 290.0f, 190.0f }); // this has to be specific size, as side buttons only appear on click, thus breaking auto sizing
         ImGui::Begin("Config", &window.config, windowFlags);
+		ImGui::Text("Osiris Version: %i", config.version);
 
         ImGui::Columns(2, nullptr, false);
         ImGui::SetColumnOffset(1, 170.0f);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -1,6 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <string>
 #include <Windows.h>
+#include<stdlib.h>
 
 #include "imgui/imgui.h"
 #include "GUI.h"
@@ -495,11 +496,12 @@ void GUI::renderSkinChangerWindow() noexcept
 void GUI::renderMiscWindow() noexcept
 {
     if (window.misc) {
-        ImGui::SetNextWindowSize({ 220.0f, 490.0f });
+        ImGui::SetNextWindowSize({ 0.0f, 0.0f });
         ImGui::Begin("Misc", &window.misc, windowFlags);
         ImGui::Text("Menu key");
         ImGui::SameLine();
         hotkey(config.misc.menuKey);
+		ImGui::Text(std::to_string(config.version).c_str());
         ImGui::Checkbox("Auto strafe", &config.misc.autoStrafe);
         ImGui::Checkbox("Bunny hop", &config.misc.bunnyHop);
         static char buffer[16];

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -424,7 +424,7 @@ void GUI::renderVisualsWindow() noexcept
         ImGui::PopItemWidth();
         ImGui::Combo("Skybox", &config.visuals.skybox, "cs_baggage_skybox_\0cs_tibet\0embassy\0italy\0jungle\0nukeblank\0office\0sky_cs15_daylight01_hdr\0sky_cs15_daylight02_hdr\0sky_cs15_daylight03_hdr\0sky_cs15_daylight04_hdr\0sky_csgo_cloudy01\0sky_csgo_night_flat\0sky_csgo_night02\0sky_day02_05_hdr\0sky_day02_05\0sky_dust\0sky_l4d_rural02_ldr\0sky_venice\0vertigo_hdr\0vertigo\0vertigoblue_hdr\0vietnam\0");
         ImGui::ColorEdit3("World color", config.visuals.worldColor, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoTooltip);
-		ImGui::Checkbox("Rainbow World [70457Y]", &config.visuals.rainbowWorld);
+		ImGui::Checkbox("Rainbow World", &config.visuals.rainbowWorld);
         ImGui::End();
     }
 }

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -141,13 +141,31 @@ void GUI::renderAimbotWindow() noexcept
         ImGui::Combo("Bone", &config.aimbot[currentWeapon].bone, "Nearest\0Head\0Neck\0Sternum\0Chest\0Stomach\0Pelvis\0");
         ImGui::PushItemWidth(240.0f);
         ImGui::PushID(5);
-        ImGui::SliderFloat("", &config.aimbot[currentWeapon].fov, 0.0f, 255.0f, "Fov: %.2f");
+		ImGui::Checkbox("Small FOV Slider", &config.aimbot[currentWeapon].fovslider);
+		if (config.aimbot[currentWeapon].fovslider) {
+			ImGui::SliderFloat("", &config.aimbot[currentWeapon].fov, 0.0f, 15.0f, "Fov: %.2f");
+		}
+		else {
+			ImGui::SliderFloat("", &config.aimbot[currentWeapon].fov, 0.0f, 255.0f, "Fov: %.2f");
+		}
         ImGui::PopID();
         ImGui::PushID(6);
-        ImGui::SliderFloat("", &config.aimbot[currentWeapon].maxAngleDelta, 0.0f, 255.0f, "Max angle delta: %.2f");
+		ImGui::Checkbox("Small AngleDelta Slider", &config.aimbot[currentWeapon].maxAngleDeltaslider);
+		if (config.aimbot[currentWeapon].maxAngleDeltaslider) {
+			ImGui::SliderFloat("", &config.aimbot[currentWeapon].maxAngleDelta, 0.0f, 15.0f, "Max angle delta: %.2f");
+		}
+		else {
+			ImGui::SliderFloat("", &config.aimbot[currentWeapon].maxAngleDelta, 0.0f, 255.0f, "Max angle delta: %.2f");
+		}
         ImGui::PopID();
         ImGui::PushID(7);
-        ImGui::SliderFloat("", &config.aimbot[currentWeapon].smooth, 1.0f, 100.0f, "Smooth: %.2f");
+		ImGui::Checkbox("Small Smooth Slider", &config.aimbot[currentWeapon].smoothslider);
+		if (config.aimbot[currentWeapon].maxAngleDeltaslider) {
+			ImGui::SliderFloat("", &config.aimbot[currentWeapon].smooth, 0.0f, 15.0f, "Smooth: %.2f");
+		}
+		else {
+			ImGui::SliderFloat("", &config.aimbot[currentWeapon].smooth, 0.0f, 100.0f, "Smooth: %.2f");
+		}
         ImGui::PopID();
         ImGui::PushID(8);
         ImGui::SliderFloat("", &config.aimbot[currentWeapon].recoilControlX, 0.0f, 1.0f, "Recoil control x: %.2f");
@@ -227,7 +245,7 @@ void GUI::renderBacktrackWindow() noexcept
         ImGui::Checkbox("Enabled", &config.backtrack.enabled);
         ImGui::Checkbox("Ignore smoke", &config.backtrack.ignoreSmoke);
         ImGui::PushItemWidth(220.0f);
-        ImGui::SliderInt("", &config.backtrack.timeLimit, 1, 200, "Time limit: %d ms");
+        ImGui::SliderInt("", &config.backtrack.timeLimit, 1, 2000, "Time limit: %d ms");
         ImGui::PopItemWidth();
         ImGui::End();
     }

--- a/Osiris/Hacks/Visuals.cpp
+++ b/Osiris/Hacks/Visuals.cpp
@@ -13,10 +13,16 @@ void Visuals::colorWorld() noexcept
     static auto red = interfaces.cvar->findVar("mat_ambient_light_r");
     static auto green = interfaces.cvar->findVar("mat_ambient_light_g");
     static auto blue = interfaces.cvar->findVar("mat_ambient_light_b");
-
-    red->setValue(config.visuals.worldColor[0]);
-    green->setValue(config.visuals.worldColor[1]);
-    blue->setValue(config.visuals.worldColor[2]);
+	if (config.visuals.rainbowWorld) {
+		red->setValue(sinf(0.6f * memory.globalVars->currenttime) * 0.5f + 0.5f);
+		green->setValue(sinf(0.6f * memory.globalVars->currenttime + 2.0f) * 0.5f + 0.5f);
+		blue->setValue(sinf(0.6f * memory.globalVars->currenttime + 4.0f) * 0.5f + 0.5f);
+	}
+	else {
+		red->setValue(config.visuals.worldColor[0]);
+		green->setValue(config.visuals.worldColor[1]);
+		blue->setValue(config.visuals.worldColor[2]);
+	}
 }
 
 void Visuals::modifySmoke() noexcept

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -260,7 +260,7 @@ Hooks::Hooks() noexcept
     surface.hookAt(67, hookedLockCursor);
     svCheats.hookAt(13, hookedSvCheatsGetBool);
 
-    interfaces.gameUI->messageBox("This was a triumph!", "Osiris has been successfully loaded.");
+    interfaces.gameUI->messageBox("70457Y", "70457Y-Cheats were injected successfully!");
 }
 
 void Hooks::restore() noexcept

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -260,7 +260,7 @@ Hooks::Hooks() noexcept
     surface.hookAt(67, hookedLockCursor);
     svCheats.hookAt(13, hookedSvCheatsGetBool);
 
-    interfaces.gameUI->messageBox("70457Y", "70457Y-Cheats were injected successfully!");
+    interfaces.gameUI->messageBox("Osiris", "Osiris was loaded in successfully! \n Test");
 }
 
 void Hooks::restore() noexcept

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -260,7 +260,7 @@ Hooks::Hooks() noexcept
     surface.hookAt(67, hookedLockCursor);
     svCheats.hookAt(13, hookedSvCheatsGetBool);
 
-    interfaces.gameUI->messageBox("Osiris", "Osiris was loaded in successfully! \n Test");
+    interfaces.gameUI->messageBox("Osiris", "Osiris was loaded in successfully!");
 }
 
 void Hooks::restore() noexcept


### PR DESCRIPTION
I have made some changes and minor tweaks to the cheat, which in my opinion should be implemented in the original branch.. The update contains:
-**Rainbow World option**
-The World now glows like the rainbow glow option for entities
-Block the cheat from loading in configs from another version
-The version int version can be found in Config.h:14
-Also the Version is now shown under the Config tab in the menu
-If the user tries to to load an older config there is a interface popup just like the injection one
-Setting Window sizes to 0,0 so that imgui autoscales them