### PR TITLE
Added an option to aim only while shooting.

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -48,7 +48,7 @@ void Config::load(size_t id) noexcept
 
         if (aimbotJson.isMember("Enabled")) aimbotConfig.enabled = aimbotJson["Enabled"].asBool();
         if (aimbotJson.isMember("On key")) aimbotConfig.onKey = aimbotJson["On key"].asBool();
-		if (aimbotJson.isMember("Only while shooting")) aimbotConfig.whileShooting = aimbotJson["On shoot"].asBool();
+        if (aimbotJson.isMember("Aimlock")) aimbotConfig.aimlock = aimbotJson["Aimlock"].asBool();
         if (aimbotJson.isMember("Key")) aimbotConfig.key = aimbotJson["Key"].asInt();
         if (aimbotJson.isMember("Key mode")) aimbotConfig.keyMode = aimbotJson["Key mode"].asInt();
         if (aimbotJson.isMember("Silent")) aimbotConfig.silent = aimbotJson["Silent"].asBool();
@@ -340,7 +340,7 @@ void Config::save(size_t id) const noexcept
 
         aimbotJson["Enabled"] = aimbotConfig.enabled;
         aimbotJson["On key"] = aimbotConfig.onKey;
-		aimbotJson["Only while shooting"] = aimbotConfig.whileShooting;
+        aimbotJson["Aimlock"] = aimbotConfig.aimlock;
         aimbotJson["Key"] = aimbotConfig.key;
         aimbotJson["Key mode"] = aimbotConfig.keyMode;
         aimbotJson["Silent"] = aimbotConfig.silent;

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -48,6 +48,7 @@ void Config::load(size_t id) noexcept
 
         if (aimbotJson.isMember("Enabled")) aimbotConfig.enabled = aimbotJson["Enabled"].asBool();
         if (aimbotJson.isMember("On key")) aimbotConfig.onKey = aimbotJson["On key"].asBool();
+		if (aimbotJson.isMember("Only while shooting")) aimbotConfig.whileShooting = aimbotJson["On shoot"].asBool();
         if (aimbotJson.isMember("Key")) aimbotConfig.key = aimbotJson["Key"].asInt();
         if (aimbotJson.isMember("Key mode")) aimbotConfig.keyMode = aimbotJson["Key mode"].asInt();
         if (aimbotJson.isMember("Silent")) aimbotConfig.silent = aimbotJson["Silent"].asBool();
@@ -339,6 +340,7 @@ void Config::save(size_t id) const noexcept
 
         aimbotJson["Enabled"] = aimbotConfig.enabled;
         aimbotJson["On key"] = aimbotConfig.onKey;
+		aimbotJson["Only while shooting"] = aimbotConfig.whileShooting;
         aimbotJson["Key"] = aimbotConfig.key;
         aimbotJson["Key mode"] = aimbotConfig.keyMode;
         aimbotJson["Silent"] = aimbotConfig.silent;

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -23,7 +23,7 @@ public:
     struct Aimbot {
         bool enabled{ false };
         bool onKey{ false };
-		bool whileShooting{ true };		// If enabled, the aimbot will only trigger while shooting.
+        bool aimlock{ true };
         int key{ 0 };
         int keyMode{ 0 };
         bool silent{ false };

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -23,6 +23,7 @@ public:
     struct Aimbot {
         bool enabled{ false };
         bool onKey{ false };
+		bool whileShooting{ true };		// If enabled, the aimbot will only trigger while shooting.
         int key{ 0 };
         int keyMode{ 0 };
         bool silent{ false };

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -187,7 +187,7 @@ void GUI::renderAimbotWindow() noexcept
         ImGui::Combo("", &config.aimbot[currentWeapon].keyMode, "Hold\0Toggle\0");
         ImGui::PopItemWidth();
         ImGui::PopID();
-		ImGui::Checkbox("Only while shooting", &config.aimbot[currentWeapon].whileShooting);
+        ImGui::Checkbox("Aimlock", &config.aimbot[currentWeapon].aimlock);
         ImGui::Checkbox("Silent", &config.aimbot[currentWeapon].silent);
         ImGui::Checkbox("Friendly fire", &config.aimbot[currentWeapon].friendlyFire);
         ImGui::Checkbox("Visible only", &config.aimbot[currentWeapon].visibleOnly);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -187,6 +187,7 @@ void GUI::renderAimbotWindow() noexcept
         ImGui::Combo("", &config.aimbot[currentWeapon].keyMode, "Hold\0Toggle\0");
         ImGui::PopItemWidth();
         ImGui::PopID();
+		ImGui::Checkbox("Only while shooting", &config.aimbot[currentWeapon].whileShooting);
         ImGui::Checkbox("Silent", &config.aimbot[currentWeapon].silent);
         ImGui::Checkbox("Friendly fire", &config.aimbot[currentWeapon].friendlyFire);
         ImGui::Checkbox("Visible only", &config.aimbot[currentWeapon].visibleOnly);

--- a/Osiris/Hacks/Aimbot.cpp
+++ b/Osiris/Hacks/Aimbot.cpp
@@ -120,7 +120,7 @@ void Aimbot::run(UserCmd* cmd) noexcept
         }
     }
 
-    if (config.aimbot[weaponIndex].enabled && (cmd->buttons & UserCmd::IN_ATTACK || config.aimbot[weaponIndex].autoShot || !config.aimbot[weaponIndex].whileShooting)) {
+    if (config.aimbot[weaponIndex].enabled && (cmd->buttons & UserCmd::IN_ATTACK || config.aimbot[weaponIndex].autoShot || config.aimbot[weaponIndex].aimlock)) {
 
         if (config.aimbot[weaponIndex].scopedOnly && activeWeapon->isSniperRifle() && !localPlayer->getProperty<bool>("m_bIsScoped"))
             return;

--- a/Osiris/Hacks/Aimbot.cpp
+++ b/Osiris/Hacks/Aimbot.cpp
@@ -120,7 +120,7 @@ void Aimbot::run(UserCmd* cmd) noexcept
         }
     }
 
-    if (config.aimbot[weaponIndex].enabled && (cmd->buttons & UserCmd::IN_ATTACK || config.aimbot[weaponIndex].autoShot)) {
+    if (config.aimbot[weaponIndex].enabled && (cmd->buttons & UserCmd::IN_ATTACK || config.aimbot[weaponIndex].autoShot || !config.aimbot[weaponIndex].whileShooting)) {
 
         if (config.aimbot[weaponIndex].scopedOnly && activeWeapon->isSniperRifle() && !localPlayer->getProperty<bool>("m_bIsScoped"))
             return;


### PR DESCRIPTION
The user will be able to select if they want the aimbot to be enabled only while they are shooting or be enabled all the time (or on key down). I personally like to have this option disabled so I can hold my aim hotkey to help me aim before I shoot.