### PR TITLE
 Fix grenade prediction config and syntax

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -360,7 +360,7 @@ void Config::load(size_t id) noexcept
         if (miscJson.isMember("Hit sound")) misc.hitSound = miscJson["Hit sound"].asInt();
         if (miscJson.isMember("Choked packets")) misc.chokedPackets = miscJson["Choked packets"].asInt();
         if (miscJson.isMember("Choked packets key")) misc.chokedPacketsKey = miscJson["Choked packets key"].asInt();
-        if (miscJson.isMember("Grenade predict")) misc.nadePredict = miscJson["Grenade Predict"].asBool();
+        if (miscJson.isMember("Grenade predict")) misc.nadePredict = miscJson["Grenade predict"].asBool();
         if (miscJson.isMember("Max angle delta")) misc.maxAngleDelta = miscJson["Max angle delta"].asFloat();
     }
 

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -220,7 +220,7 @@ public:
         int hitSound{ 0 };
         int chokedPackets{ 0 };
         int chokedPacketsKey{ 0 };
-        bool nadePredict {false};
+        bool nadePredict{ false };
         float maxAngleDelta{ 255.0f };
     } misc;
 

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -347,7 +347,7 @@ void Misc::fakeBan(bool set) noexcept
 
 void Misc::nadePredict() noexcept
 { 
-    static auto nadeVar = interfaces.cvar->findVar("cl_grenadepreview"); 
+    static auto nadeVar{ interfaces.cvar->findVar("cl_grenadepreview") }; 
     
     nadeVar->onChangeCallbacks.size = 0; 
     nadeVar->setValue(config.misc.nadePredict); 


### PR DESCRIPTION
Settings of new grenade prediction is not saving due typo. Also fixed syntax to match code style.