### PR TITLE
Draw all backtrack Chams

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -93,6 +93,7 @@ void Config::load(size_t id) noexcept
         if (backtrackJson.isMember("Enabled")) backtrack.enabled = backtrackJson["Enabled"].asBool();
         if (backtrackJson.isMember("Ignore smoke")) backtrack.ignoreSmoke = backtrackJson["Ignore smoke"].asBool();
         if (backtrackJson.isMember("Recoil based fov")) backtrack.recoilBasedFov = backtrackJson["Recoil based fov"].asBool();
+        if (backtrackJson.isMember("Draw all ticks")) backtrack.drawAllTicks = backtrackJson["Draw all ticks"].asBool();
         if (backtrackJson.isMember("Time limit")) backtrack.timeLimit = backtrackJson["Time limit"].asInt();
     }
 
@@ -943,6 +944,7 @@ void Config::save(size_t id) const noexcept
         backtrackJson["Enabled"] = backtrack.enabled;
         backtrackJson["Ignore smoke"] = backtrack.ignoreSmoke;
         backtrackJson["Recoil based fov"] = backtrack.recoilBasedFov;
+        backtrackJson["Draw all ticks"] = backtrack.drawAllTicks;
         backtrackJson["Time limit"] = backtrack.timeLimit;
     }
 

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -78,6 +78,7 @@ public:
         bool enabled{ false };
         bool ignoreSmoke{ false };
         bool recoilBasedFov{ false };
+        bool drawAllTicks{ false };
         int timeLimit{ 200 };
     } backtrack;
 

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -406,6 +406,7 @@ void GUI::renderBacktrackWindow() noexcept
         ImGui::Checkbox("Enabled", &config.backtrack.enabled);
         ImGui::Checkbox("Ignore smoke", &config.backtrack.ignoreSmoke);
         ImGui::Checkbox("Recoil based fov", &config.backtrack.recoilBasedFov);
+        ImGui::Checkbox("Draw all ticks", &config.backtrack.drawAllTicks);
         ImGui::PushItemWidth(220.0f);
         ImGui::SliderInt("", &config.backtrack.timeLimit, 1, 200, "Time limit: %d ms");
         ImGui::PopItemWidth();

--- a/Osiris/Hacks/Chams.cpp
+++ b/Osiris/Hacks/Chams.cpp
@@ -160,12 +160,12 @@ bool Chams::renderPlayers(void* ctx, void* state, const ModelRenderInfo& info, m
                             hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, customBoneToWorld);
                         applyChams(config.chams[BACKTRACK].materials[i], false, entity->health());
                         if (config.backtrack.drawAllTicks) {
-							for (int x = 0; x < record->size(); x++) {
-								hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->at(x).matrix);
-							}
-						}
-						else
-							hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
+				for (int x = 0; x < record->size(); x++) {
+					hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->at(x).matrix);
+				}
+			}
+			else
+				hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
                         interfaces.modelRender->forceMaterialOverride(nullptr);
                         applied = true;
                     }

--- a/Osiris/Hacks/Chams.cpp
+++ b/Osiris/Hacks/Chams.cpp
@@ -159,7 +159,13 @@ bool Chams::renderPlayers(void* ctx, void* state, const ModelRenderInfo& info, m
                         if (applied)
                             hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, customBoneToWorld);
                         applyChams(config.chams[BACKTRACK].materials[i], false, entity->health());
-                        hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
+                        if (config.backtrack.drawAllTicks) {
+							for (int x = 0; x < record->size(); x++) {
+								hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->at(x).matrix);
+							}
+						}
+						else
+							hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
                         interfaces.modelRender->forceMaterialOverride(nullptr);
                         applied = true;
                     }


### PR DESCRIPTION
Added option to draw all backtrack Chams.

Daniel will want to change where the config is stored but I'm lazy so just added to backtrack.