### PR TITLE
Close This//Close This//Thank you

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -85,6 +85,7 @@ void Config::load(size_t id) noexcept
         if (backtrackJson.isMember("Enabled")) backtrack.enabled = backtrackJson["Enabled"].asBool();
         if (backtrackJson.isMember("Ignore smoke")) backtrack.ignoreSmoke = backtrackJson["Ignore smoke"].asBool();
         if (backtrackJson.isMember("Recoil based fov")) backtrack.recoilBasedFov = backtrackJson["Recoil based fov"].asBool();
+		if (backtrackJson.isMember("Draw all ticks")) backtrack.drawAllTicks = backtrackJson["Draw all ticks"].asBool();
         if (backtrackJson.isMember("Time limit")) backtrack.timeLimit = backtrackJson["Time limit"].asInt();
     }
 
@@ -366,8 +367,7 @@ void Config::load(size_t id) noexcept
             if (distanceJson.isMember("Rainbow")) distanceConfig.rainbow = distanceJson["Rainbow"].asBool();
             if (distanceJson.isMember("Rainbow speed")) distanceConfig.rainbowSpeed = distanceJson["Rainbow speed"].asFloat();
         }
-        
-        if (espJson.isMember("Dead ESP")) espConfig.deadesp = espJson["Dead ESP"].asBool();
+
         if (espJson.isMember("Max distance")) espConfig.maxDistance = espJson["Max distance"].asFloat();
     }
 
@@ -688,7 +688,9 @@ void Config::load(size_t id) noexcept
         if (visualsJson.isMember("Screen effect")) visuals.screenEffect = visualsJson["Screen effect"].asInt();
         if (visualsJson.isMember("Hit marker")) visuals.hitMarker = visualsJson["Hit marker"].asInt();
         if (visualsJson.isMember("Hit marker time")) visuals.hitMarkerTime = visualsJson["Hit marker time"].asFloat();
-    }
+		if (visualsJson.isMember("Hit marker Damage Indicator")) visuals.hitMarkerDamageIndicator = visualsJson["Hit marker Damage Indicator"].asBool();
+	
+ }
 
     for (size_t i = 0; i < skinChanger.size(); i++) {
         const auto& skinChangerJson = json["skinChanger"][i];
@@ -941,6 +943,7 @@ void Config::save(size_t id) const noexcept
         backtrackJson["Enabled"] = backtrack.enabled;
         backtrackJson["Ignore smoke"] = backtrack.ignoreSmoke;
         backtrackJson["Recoil based fov"] = backtrack.recoilBasedFov;
+		backtrackJson["Draw all ticks"] = backtrack.drawAllTicks;
         backtrackJson["Time limit"] = backtrack.timeLimit;
     }
 
@@ -1170,7 +1173,6 @@ void Config::save(size_t id) const noexcept
             distanceJson["Rainbow speed"] = distanceConfig.rainbowSpeed;
         }
 
-        espJson["Dead ESP"] = espConfig.deadesp;
         espJson["Max distance"] = espConfig.maxDistance;
     }
 
@@ -1430,6 +1432,7 @@ void Config::save(size_t id) const noexcept
         visualsJson["Screen effect"] = visuals.screenEffect;
         visualsJson["Hit marker"] = visuals.hitMarker;
         visualsJson["Hit marker time"] = visuals.hitMarkerTime;
+		visualsJson["Hit marker Damage Indicator"] = visuals.hitMarkerDamageIndicator;
     }
 
     for (size_t i = 0; i < skinChanger.size(); i++) {

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -91,7 +91,6 @@ void Config::load(size_t id) noexcept
 		if (backtrackJson.isMember("Draw all ticks")) backtrack.drawAllTicks = backtrackJson["Draw all ticks"].asBool();
     }
 
-
     {
         const auto& antiAimJson = json["Anti aim"];
         if (antiAimJson.isMember("Enabled")) antiAim.enabled = antiAimJson["Enabled"].asBool();

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -724,11 +724,15 @@ void Config::load(size_t id) noexcept
 		if (visualsJson.isMember("Custom Viewmodel Knife Out")) visuals.customViewmodelKnifeOut = visualsJson["Custom Viewmodel Knife Out"].asBool();
 		if (visualsJson.isMember("Custom Viewmodel Knife Enabled")) visuals.customViewmodelKnifeEnabled = visualsJson["Custom Viewmodel Knife Enabled"].asBool();
 		if (visualsJson.isMember("Custom Viewmodel Knife Menu Switch")) visuals.customViewmodelMenuSwitch = visualsJson["Custom Viewmodel Menu Switch"].asBool();
+		if (visualsJson.isMember("Custom Viewmodel Knife Switch Hand")) visuals.customViewmodelSwitchHand = visualsJson["Custom Viewmodel Menu Switch Hand"].asBool();
+		if (visualsJson.isMember("Custom Viewmodel Knife Switch Hand Knife")) visuals.customViewmodelSwitchHandKnife = visualsJson["Custom Viewmodel Switch Hand Knife"].asBool();
 		if (visualsJson.isMember("Custom Viewmodel Bob")) visuals.view_bob = visualsJson["Custom Viewmodel Bob"].asBool();
 		if (visualsJson.isMember("Full Brightness Light")) visuals.full_bright = visualsJson["Full Brightness Light"].asBool();
 		if (visualsJson.isMember("Playermodel T")) visuals.playerModelT = visualsJson["Playermodel T"].asInt();
         if (visualsJson.isMember("Playermodel CT")) visuals.playerModelCT = visualsJson["Playermodel CT"].asInt();
     }
+
+
 
     for (size_t i = 0; i < skinChanger.size(); i++) {
         const auto& skinChangerJson = json["skinChanger"][i];
@@ -1493,6 +1497,8 @@ void Config::save(size_t id) const noexcept
 		visualsJson["Custom Viewmodel Knife Toggle"] = visuals.customViewmodelKnifeToggle;
 		visualsJson["Custom Viewmodel Knife Enabled"] = visuals.customViewmodelKnifeEnabled;
 		visualsJson["Custom Viewmodel Knife Switch"] = visuals.customViewmodelMenuSwitch;
+		visualsJson["Custom Viewmodel Switch Hand"] = visuals.customViewmodelSwitchHand;
+		visualsJson["Custom Viewmodel Switch Hand Knife"] = visuals.customViewmodelSwitchHandKnife;
 		visualsJson["Custom Viewmodel X Knife"] = visuals.viewmodel_x_knife;
 		visualsJson["Custom Viewmodel Y Knife"] = visuals.viewmodel_y_knife;
 		visualsJson["Custom Viewmodel Z Knife"] = visuals.viewmodel_z_knife;

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -652,7 +652,8 @@ void Config::load(size_t id) noexcept
         if (visualsJson.isMember("disablePostProcessing")) visuals.disablePostProcessing = visualsJson["disablePostProcessing"].asBool();
         if (visualsJson.isMember("inverseRagdollGravity")) visuals.inverseRagdollGravity = visualsJson["inverseRagdollGravity"].asBool();
 		if (visualsJson.isMember("inverseRagdollGravityValue")) visuals.inverseRagdollGravityValue = visualsJson["inverseRagdollGravityValue"].asInt();
-        if (visualsJson.isMember("noFog")) visuals.noFog = visualsJson["noFog"].asBool();
+		if (visualsJson.isMember("inverseRagdollGravityCustomize")) visuals.inverseRagdollGravityCustomize = visualsJson["inverseRagdollGravityCustomize"].asBool();
+		if (visualsJson.isMember("noFog")) visuals.noFog = visualsJson["noFog"].asBool();
         if (visualsJson.isMember("no3dSky")) visuals.no3dSky = visualsJson["no3dSky"].asBool();
         if (visualsJson.isMember("No aim punch")) visuals.noAimPunch = visualsJson["No aim punch"].asBool();
         if (visualsJson.isMember("No view punch")) visuals.noViewPunch = visualsJson["No view punch"].asBool();
@@ -723,6 +724,7 @@ void Config::load(size_t id) noexcept
 		if (visualsJson.isMember("Custom Viewmodel Knife Toggle")) visuals.customViewmodelKnifeToggle = visualsJson["Custom Viewmodel Knife Toggle"].asBool();
 		if (visualsJson.isMember("Custom Viewmodel Knife Out")) visuals.customViewmodelKnifeOut = visualsJson["Custom Viewmodel Knife Out"].asBool();
 		if (visualsJson.isMember("Custom Viewmodel Knife Enabled")) visuals.customViewmodelKnifeEnabled = visualsJson["Custom Viewmodel Knife Enabled"].asBool();
+		if (visualsJson.isMember("Custom Viewmodel Knife Menu Switch")) visuals.customViewmodelMenuSwitch = visualsJson["Custom Viewmodel Menu Switch"].asBool();
 		if (visualsJson.isMember("Custom Viewmodel Bob")) visuals.view_bob = visualsJson["Custom Viewmodel Bob"].asBool();
 		if (visualsJson.isMember("Full Brightness Light")) visuals.full_bright = visualsJson["Full Brightness Light"].asBool();
 		if (visualsJson.isMember("Playermodel T")) visuals.playerModelT = visualsJson["Playermodel T"].asInt();
@@ -1428,6 +1430,7 @@ void Config::save(size_t id) const noexcept
         visualsJson["disablePostProcessing"] = visuals.disablePostProcessing;
         visualsJson["inverseRagdollGravity"] = visuals.inverseRagdollGravity;
 		visualsJson["inverseRagdollGravityValue"] = visuals.inverseRagdollGravityValue;
+		visualsJson["inverseRagdollGravityCustomize"] = visuals.inverseRagdollGravityCustomize;
         visualsJson["noFog"] = visuals.noFog;
         visualsJson["no3dSky"] = visuals.no3dSky;
         visualsJson["No aim punch"] = visuals.noAimPunch;
@@ -1489,6 +1492,8 @@ void Config::save(size_t id) const noexcept
 		visualsJson["Custom Viewmodel Y"] = visuals.viewmodel_y;
 		visualsJson["Custom Viewmodel Z"] = visuals.viewmodel_z;
 		visualsJson["Custom Viewmodel Knife Toggle"] = visuals.customViewmodelKnifeToggle;
+		visualsJson["Custom Viewmodel Knife Enabled"] = visuals.customViewmodelKnifeEnabled;
+		visualsJson["Custom Viewmodel Knife Switch"] = visuals.customViewmodelMenuSwitch;
 		visualsJson["Custom Viewmodel X Knife"] = visuals.viewmodel_x_knife;
 		visualsJson["Custom Viewmodel Y Knife"] = visuals.viewmodel_y_knife;
 		visualsJson["Custom Viewmodel Z Knife"] = visuals.viewmodel_z_knife;

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -88,7 +88,7 @@ void Config::load(size_t id) noexcept
         if (backtrackJson.isMember("Time limit")) backtrack.timeLimit = backtrackJson["Time limit"].asInt();
 		if (backtrackJson.isMember("pingBasedPing")) backtrack.timeLimit = backtrackJson["pingBasedPing"].asFloat();
 		if (backtrackJson.isMember("pingBased")) backtrack.timeLimit = backtrackJson["pingBased"].asBool();
-
+		if (backtrackJson.isMember("Draw all ticks")) backtrack.drawAllTicks = backtrackJson["Draw all ticks"].asBool();
     }
 
 
@@ -651,6 +651,7 @@ void Config::load(size_t id) noexcept
         const auto& visualsJson = json["visuals"];
         if (visualsJson.isMember("disablePostProcessing")) visuals.disablePostProcessing = visualsJson["disablePostProcessing"].asBool();
         if (visualsJson.isMember("inverseRagdollGravity")) visuals.inverseRagdollGravity = visualsJson["inverseRagdollGravity"].asBool();
+		if (visualsJson.isMember("inverseRagdollGravityValue")) visuals.inverseRagdollGravityValue = visualsJson["inverseRagdollGravityValue"].asInt();
         if (visualsJson.isMember("noFog")) visuals.noFog = visualsJson["noFog"].asBool();
         if (visualsJson.isMember("no3dSky")) visuals.no3dSky = visualsJson["no3dSky"].asBool();
         if (visualsJson.isMember("No aim punch")) visuals.noAimPunch = visualsJson["No aim punch"].asBool();
@@ -705,7 +706,26 @@ void Config::load(size_t id) noexcept
         if (visualsJson.isMember("Screen effect")) visuals.screenEffect = visualsJson["Screen effect"].asInt();
         if (visualsJson.isMember("Hit marker")) visuals.hitMarker = visualsJson["Hit marker"].asInt();
         if (visualsJson.isMember("Hit marker time")) visuals.hitMarkerTime = visualsJson["Hit marker time"].asFloat();
-        if (visualsJson.isMember("Playermodel T")) visuals.playerModelT = visualsJson["Playermodel T"].asInt();
+		if (visualsJson.isMember("Hit marker Damage Indicator")) visuals.hitMarkerDamageIndicator = visualsJson["Hit marker Damage Indicator"].asBool();
+		if (visualsJson.isMember("Hit marker Damage Indicator Dist")) visuals.hitMarkerDamageIndicatorDist = visualsJson["Hit marker Damage Indicator Dist"].asInt();
+		if (visualsJson.isMember("Hit marker Damage Indicator Ratio")) visuals.hitMarkerDamageIndicatorRatio = visualsJson["Hit marker Damage Indicator Ratio"].asFloat();
+		if (visualsJson.isMember("Hit marker Damage Indicator Alpha")) visuals.hitMarkerDamageIndicatorAlpha = visualsJson["Hit marker Damage Indicator Alpha"].asInt();
+		if (visualsJson.isMember("Hit marker Damage Indicator Font")) visuals.hitMarkerDamageIndicatorFont = visualsJson["Hit marker Damage Indicator Font"].asInt();
+		if (visualsJson.isMember("Hit marker Damage Indicator Text X")) visuals.hitMarkerDamageIndicatorTextX = visualsJson["Hit marker Damage Indicator Text X"].asInt();
+		if (visualsJson.isMember("Hit marker Damage Indicator Text Y")) visuals.hitMarkerDamageIndicatorTextY = visualsJson["Hit marker Damage Indicator Text Y"].asInt();
+		if (visualsJson.isMember("Custom Viewmodel Toggle")) visuals.customViewmodelToggle = visualsJson["Custom Viewmodel Toggle"].asBool();
+		if (visualsJson.isMember("Custom Viewmodel X")) visuals.viewmodel_x = visualsJson["Custom Viewmodel X"].asFloat();
+		if (visualsJson.isMember("Custom Viewmodel Y")) visuals.viewmodel_y = visualsJson["Custom Viewmodel Y"].asFloat();
+		if (visualsJson.isMember("Custom Viewmodel Z")) visuals.viewmodel_z = visualsJson["Custom Viewmodel Z"].asFloat();
+		if (visualsJson.isMember("Custom Viewmodel X Knife")) visuals.viewmodel_x_knife = visualsJson["Custom Viewmodel X Knife"].asFloat();
+		if (visualsJson.isMember("Custom Viewmodel Y Knife")) visuals.viewmodel_y_knife = visualsJson["Custom Viewmodel Y Knife"].asFloat();
+		if (visualsJson.isMember("Custom Viewmodel Z Knife")) visuals.viewmodel_z_knife = visualsJson["Custom Viewmodel Z Knife"].asFloat();
+		if (visualsJson.isMember("Custom Viewmodel Knife Toggle")) visuals.customViewmodelKnifeToggle = visualsJson["Custom Viewmodel Knife Toggle"].asBool();
+		if (visualsJson.isMember("Custom Viewmodel Knife Out")) visuals.customViewmodelKnifeOut = visualsJson["Custom Viewmodel Knife Out"].asBool();
+		if (visualsJson.isMember("Custom Viewmodel Knife Enabled")) visuals.customViewmodelKnifeEnabled = visualsJson["Custom Viewmodel Knife Enabled"].asBool();
+		if (visualsJson.isMember("Custom Viewmodel Bob")) visuals.view_bob = visualsJson["Custom Viewmodel Bob"].asBool();
+		if (visualsJson.isMember("Full Brightness Light")) visuals.full_bright = visualsJson["Full Brightness Light"].asBool();
+		if (visualsJson.isMember("Playermodel T")) visuals.playerModelT = visualsJson["Playermodel T"].asInt();
         if (visualsJson.isMember("Playermodel CT")) visuals.playerModelCT = visualsJson["Playermodel CT"].asInt();
     }
 
@@ -880,7 +900,8 @@ void Config::load(size_t id) noexcept
         if (miscJson.isMember("Fix tablet signal")) misc.fixTabletSignal = miscJson["Fix tablet signal"].asBool();
         if (miscJson.isMember("Max angle delta")) misc.maxAngleDelta = miscJson["Max angle delta"].asFloat();
         if (miscJson.isMember("Fake prime")) misc.fakePrime = miscJson["Fake prime"].asBool();
-    }
+
+	}
 
     {
         const auto& reportbotJson = json["Reportbot"];
@@ -954,8 +975,11 @@ void Config::save(size_t id) const noexcept
         backtrackJson["Ignore smoke"] = backtrack.ignoreSmoke;
         backtrackJson["Recoil based fov"] = backtrack.recoilBasedFov;
         backtrackJson["Time limit"] = backtrack.timeLimit;
+		backtrackJson["Draw all ticks"] = backtrack.drawAllTicks;
+		backtrackJson["pingBased"] = backtrack.pingBased;
+		
     }
-
+	
     {
         auto& antiAimJson = json["Anti aim"];
         antiAimJson["Enabled"] = antiAim.enabled;
@@ -1403,6 +1427,7 @@ void Config::save(size_t id) const noexcept
         auto& visualsJson = json["visuals"];
         visualsJson["disablePostProcessing"] = visuals.disablePostProcessing;
         visualsJson["inverseRagdollGravity"] = visuals.inverseRagdollGravity;
+		visualsJson["inverseRagdollGravityValue"] = visuals.inverseRagdollGravityValue;
         visualsJson["noFog"] = visuals.noFog;
         visualsJson["no3dSky"] = visuals.no3dSky;
         visualsJson["No aim punch"] = visuals.noAimPunch;
@@ -1452,6 +1477,23 @@ void Config::save(size_t id) const noexcept
         visualsJson["Screen effect"] = visuals.screenEffect;
         visualsJson["Hit marker"] = visuals.hitMarker;
         visualsJson["Hit marker time"] = visuals.hitMarkerTime;
+		visualsJson["Hit marker Damage Indicator"] = visuals.hitMarkerDamageIndicator;
+		visualsJson["Hit marker Damage Indicator Dist"] = visuals.hitMarkerDamageIndicatorDist;
+		visualsJson["Hit marker Damage Indicator Ratio"] = visuals.hitMarkerDamageIndicatorRatio;
+		visualsJson["Hit marker Damage Indicator Aplha"] = visuals.hitMarkerDamageIndicatorAlpha;
+		visualsJson["Hit marker Damage Indicator Font"] = visuals.hitMarkerDamageIndicatorFont;
+		visualsJson["Hit marker Damage Indicator Text X"] = visuals.hitMarkerDamageIndicatorTextX;
+		visualsJson["Hit marker Damage Indicator Text Y"] = visuals.hitMarkerDamageIndicatorTextY;
+		visualsJson["Custom Viewmodel Toggle"] = visuals.customViewmodelToggle;
+		visualsJson["Custom Viewmodel X"] = visuals.viewmodel_x;
+		visualsJson["Custom Viewmodel Y"] = visuals.viewmodel_y;
+		visualsJson["Custom Viewmodel Z"] = visuals.viewmodel_z;
+		visualsJson["Custom Viewmodel Knife Toggle"] = visuals.customViewmodelKnifeToggle;
+		visualsJson["Custom Viewmodel X Knife"] = visuals.viewmodel_x_knife;
+		visualsJson["Custom Viewmodel Y Knife"] = visuals.viewmodel_y_knife;
+		visualsJson["Custom Viewmodel Z Knife"] = visuals.viewmodel_z_knife;
+		visualsJson["Custom Viewmodel Bob"] = visuals.view_bob;
+		visualsJson["Full Brightness Light"] = visuals.full_bright;
         visualsJson["Playermodel T"] = visuals.playerModelT;
         visualsJson["Playermodel CT"] = visuals.playerModelCT;
     }

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -189,7 +189,7 @@ public:
         float hitMarkerTime{ 1.0f };
 		bool hitMarkerDamageIndicator{ false };
 		int hitMarkerDamageIndicatorDist{ 150 };
-		float hitMarkerDamageIndicatorRatio{ 1.0f };
+		float hitMarkerDamageIndicatorRatio{ 0.0f };
 		int hitMarkerDamageIndicatorAlpha{ 800 };
 		int hitMarkerDamageIndicatorFont{ 31 };
 		int hitMarkerDamageIndicatorTextX{ 60 };

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -78,8 +78,9 @@ public:
         bool enabled{ false };
         bool ignoreSmoke{ false };
         bool recoilBasedFov{ false };
-		bool drawAllTicks{ false };
         int timeLimit{ 200 };
+		bool pingBased{ 0 };
+		float pingBasedPing{ 0.0f };
     } backtrack;
 
     struct {
@@ -136,6 +137,7 @@ public:
             ColorToggle money;
             ColorToggle headDot;
             ColorToggle activeWeapon;
+            bool deadesp { false };
         };
 
         struct Weapon : public Shared { } weapon;
@@ -177,11 +179,13 @@ public:
         float brightness{ 0.0f };
         int skybox{ 0 };
         ColorToggle world;
+        ColorToggle sky;
         bool deagleSpinner{ false };
         int screenEffect{ 0 };
         int hitMarker{ 0 };
         float hitMarkerTime{ 0.6f };
-		bool hitMarkerDamageIndicator{ false };
+        int playerModelT{ 0 };
+        int playerModelCT{ 0 };
     } visuals;
 
     std::array<item_setting, 36> skinChanger;
@@ -215,6 +219,8 @@ public:
         bool animatedClanTag{ false };
         bool fastDuck{ false };
         bool moonwalk{ false };
+        bool slowwalk{ false };
+        int slowwalkKey{ 0 };
         bool sniperCrosshair{ false };
         bool recoilCrosshair{ false };
         bool autoPistol{ false };
@@ -249,6 +255,7 @@ public:
         bool nadePredict{ false };
         bool fixTabletSignal{ false };
         float maxAngleDelta{ 255.0f };
+        bool fakePrime{ false };
     } misc;
 
     struct {

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -24,7 +24,7 @@ public:
     struct Color {
         float color[3]{ 1.0f, 1.0f, 1.0f };
         bool rainbow{ false };
-        float rainbowSpeed{ 0.6f };
+        float rainbowSpeed{ 1.0f };
     };
     
     struct ColorToggle : public Color {
@@ -81,6 +81,7 @@ public:
         int timeLimit{ 200 };
 		bool pingBased{ 0 };
 		float pingBasedPing{ 0.0f };
+		bool drawAllTicks{ true };
     } backtrack;
 
     struct {
@@ -154,6 +155,8 @@ public:
     struct {
         bool disablePostProcessing{ false };
         bool inverseRagdollGravity{ false };
+		int inverseRagdollGravityValue{ -600 };
+		bool inverseRagdollGravityCustomize{ false };
         bool noFog{ false };
         bool no3dSky{ false };
         bool noAimPunch{ false };
@@ -183,7 +186,27 @@ public:
         bool deagleSpinner{ false };
         int screenEffect{ 0 };
         int hitMarker{ 0 };
-        float hitMarkerTime{ 0.6f };
+        float hitMarkerTime{ 1.0f };
+		bool hitMarkerDamageIndicator{ false };
+		int hitMarkerDamageIndicatorDist{ 150 };
+		float hitMarkerDamageIndicatorRatio{ 1.0f };
+		int hitMarkerDamageIndicatorAlpha{ 800 };
+		int hitMarkerDamageIndicatorFont{ 31 };
+		int hitMarkerDamageIndicatorTextX{ 60 };
+		int hitMarkerDamageIndicatorTextY{ 150 };
+		bool customViewmodelToggle{ false };
+		float viewmodel_x{ 0 };
+		float viewmodel_y{ 0 };
+		float viewmodel_z{ 0 };
+		bool customViewmodelKnifeToggle{ false };
+		bool customViewmodelKnifeOut{ false };
+		bool customViewmodelKnifeEnabled{ false };
+		bool customViewmodelMenuSwitch{ false };
+		float viewmodel_x_knife{ 0 };
+		float viewmodel_y_knife{ 0 };
+		float viewmodel_z_knife{ 0 };
+		bool view_bob{ false };
+		bool full_bright{ false };
         int playerModelT{ 0 };
         int playerModelCT{ 0 };
     } visuals;
@@ -237,12 +260,12 @@ public:
         bool fixMovement{ false };
         bool disableModelOcclusion{ false };
         bool killMessage{ false };
-        char killMessageString[230]{ "Gotcha!" };
+        char killMessageString[230]{ "1" };
         bool nameStealer{ false };
         bool disablePanoramablur{ false };
-        char voteText[50]{ "" };
+        char voteText[50]{ "vote text" };
         int banColor{ 6 };
-        char banText[150]{ "Cheater has been permanently banned from official CS:GO servers." };
+        char banText[150]{ "ban text" };
         bool fastPlant{ false };
         ColorToggle bombTimer{ 1.0f, 0.55f, 0.0f };
         bool quickReload{ false };
@@ -256,15 +279,17 @@ public:
         bool fixTabletSignal{ false };
         float maxAngleDelta{ 255.0f };
         bool fakePrime{ false };
+
+
     } misc;
 
     struct {
         bool enabled{ false };
         int target{ 0 };
-        int delay{ 10 };
+        int delay{ 1 };
         bool aimbot{ true };
         bool wallhack{ true };
-        bool other{ true };
+        bool other{ false };
         bool griefing{ false };
         bool voiceAbuse{ false };
         bool textAbuse{ false };

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -78,6 +78,7 @@ public:
         bool enabled{ false };
         bool ignoreSmoke{ false };
         bool recoilBasedFov{ false };
+		bool drawAllTicks{ false };
         int timeLimit{ 200 };
     } backtrack;
 
@@ -135,7 +136,6 @@ public:
             ColorToggle money;
             ColorToggle headDot;
             ColorToggle activeWeapon;
-            bool deadesp { false };
         };
 
         struct Weapon : public Shared { } weapon;
@@ -181,6 +181,7 @@ public:
         int screenEffect{ 0 };
         int hitMarker{ 0 };
         float hitMarkerTime{ 0.6f };
+		bool hitMarkerDamageIndicator{ false };
     } visuals;
 
     std::array<item_setting, 36> skinChanger;

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -202,6 +202,9 @@ public:
 		bool customViewmodelKnifeOut{ false };
 		bool customViewmodelKnifeEnabled{ false };
 		bool customViewmodelMenuSwitch{ false };
+		bool customViewmodelBombEquiped{ false };
+		bool customViewmodelSwitchHand{ false };
+		bool customViewmodelSwitchHandKnife{ false };
 		float viewmodel_x_knife{ 0 };
 		float viewmodel_y_knife{ 0 };
 		float viewmodel_z_knife{ 0 };

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -203,8 +203,8 @@ public:
 		bool customViewmodelKnifeEnabled{ false };
 		bool customViewmodelMenuSwitch{ false };
 		bool customViewmodelBombEquiped{ false };
-		bool customViewmodelSwitchHand{ false };
-		bool customViewmodelSwitchHandKnife{ false };
+		bool customViewmodelSwitchHand{ true };
+		bool customViewmodelSwitchHandKnife{ true };
 		float viewmodel_x_knife{ 0 };
 		float viewmodel_y_knife{ 0 };
 		float viewmodel_z_knife{ 0 };

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -406,7 +406,8 @@ void GUI::renderBacktrackWindow() noexcept
         ImGui::Checkbox("Enabled", &config.backtrack.enabled);
         ImGui::Checkbox("Ignore smoke", &config.backtrack.ignoreSmoke);
         ImGui::Checkbox("Recoil based fov", &config.backtrack.recoilBasedFov);
-        ImGui::PushItemWidth(220.0f);
+		ImGui::Checkbox("Draw all ticks", &config.backtrack.drawAllTicks);
+        ImGui::PushItemWidth(200.0f);
         ImGui::SliderInt("", &config.backtrack.timeLimit, 1, 200, "Time limit: %d ms");
         ImGui::PopItemWidth();
         if (!config.style.menuStyle)
@@ -499,8 +500,6 @@ void GUI::renderChamsWindow() noexcept
         ImGui::Combo("Material", &chams.material, "Normal\0Flat\0Animated\0Platinum\0Glass\0Chrome\0Crystal\0Silver\0Gold\0Plastic\0");
         ImGui::Checkbox("Wireframe", &chams.wireframe);
         ImGuiCustom::colorPicker("Color", chams.color.color, nullptr, &chams.color.rainbow, &chams.color.rainbowSpeed);
-        ImGui::SetNextItemWidth(220.0f);
-        ImGui::SliderFloat("Alpha", &chams.alpha, 0.0f, 1.0f, "%.2f");
 
         if (!config.style.menuStyle) {
             ImGui::End();
@@ -634,8 +633,6 @@ void GUI::renderEspWindow() noexcept
                 ImGui::SameLine(spacing);
                 ImGuiCustom::colorPicker("Distance", config.esp.players[selected].distance);
                 ImGuiCustom::colorPicker("Active Weapon", config.esp.players[selected].activeWeapon);
-                ImGui::SameLine(spacing);
-                ImGui::Checkbox("Dead ESP", &config.esp.players[selected].deadesp);
                 ImGui::SliderFloat("Max distance", &config.esp.players[selected].maxDistance, 0.0f, 200.0f, "%.2fm");
                 break;
             }
@@ -773,7 +770,8 @@ void GUI::renderVisualsWindow() noexcept
         ImGuiCustom::colorPicker("World color", config.visuals.world);
         ImGui::Checkbox("Deagle spinner", &config.visuals.deagleSpinner);
         ImGui::Combo("Screen effect", &config.visuals.screenEffect, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
-        ImGui::Combo("Hit marker", &config.visuals.hitMarker, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
+        ImGui::Combo("Hit marker", &config.visuals.hitMarker, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0Classic Hitmarker\0");
+		ImGui::Checkbox("Hit Damage", &config.visuals.hitMarkerDamageIndicator);
         ImGui::SliderFloat("Hit marker time", &config.visuals.hitMarkerTime, 0.1f, 1.5f, "%.2fs");
         ImGui::Columns(1);
 

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -781,6 +781,7 @@ void GUI::renderVisualsWindow() noexcept
 			ImGui::PushID(7);
 			ImGui::SliderFloat("", &config.visuals.viewmodel_z, -20, 20, "Down/Up: %.2f");
 			ImGui::PopID();
+			ImGui::Checkbox("Right/Left hand Weapon", &config.visuals.customViewmodelSwitchHand);
 			//if (ImGui::Button("Update Viewmodel"))
 			//	Visuals::customViewmodel();
 		};
@@ -798,6 +799,7 @@ void GUI::renderVisualsWindow() noexcept
 			ImGui::PushID(12);
 			ImGui::SliderFloat("", &config.visuals.viewmodel_z_knife, -20, 20, "Down/Up: %.2f");
 			ImGui::PopID();
+			ImGui::Checkbox("Right/Left hand Knife", &config.visuals.customViewmodelSwitchHandKnife);
 		};
 
         ImGui::NextColumn();

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -846,8 +846,7 @@ void GUI::renderVisualsWindow() noexcept
         ImGui::Combo("HitMark", &config.visuals.hitMarker, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
 		ImGui::Checkbox("Hit Damage", &config.visuals.hitMarkerDamageIndicator);
 		ImGui::PushID(14);
-		ImGui::PushItemWidth(280.0f);
-        ImGui::SliderFloat(" ", &config.visuals.hitMarkerTime, 0.01f, 1.0f, "Hit marker time: %.2fs");
+        ImGui::SliderFloat("", &config.visuals.hitMarkerTime, 0.01f, 1.0f, "Hit marker time: %.2fs");
 		ImGui::PopID();
 		if (config.visuals.hitMarkerDamageIndicator) {
 			ImGui::InputInt("Font", &config.visuals.hitMarkerDamageIndicatorFont, 1, 294);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -752,12 +752,12 @@ void GUI::renderVisualsWindow() noexcept
 		ImGui::Checkbox("Flip ragdoll gravity", &config.visuals.inverseRagdollGravity);
 		if (config.visuals.inverseRagdollGravity) {
 			ImGui::SameLine();
-			ImGui::Checkbox("Custom ragdoll gravity", &config.visuals.inverseRagdollGravityCustomize);
+			ImGui::Checkbox("Custom gravity", &config.visuals.inverseRagdollGravityCustomize);
 		};
 		if (config.visuals.inverseRagdollGravityCustomize&&config.visuals.inverseRagdollGravity) {
 			ImGui::InputInt("Gravity Value", &config.visuals.inverseRagdollGravityValue, -2400, 2400);
 		};
-		ImGui::Checkbox("Custom Viewmodel", &config.visuals.customViewmodelToggle);
+		ImGui::Checkbox("Viewmodel Position", &config.visuals.customViewmodelToggle);
 		if (!config.visuals.customViewmodelToggle) {
 			config.visuals.customViewmodelKnifeEnabled = 0;
 		};
@@ -844,10 +844,11 @@ void GUI::renderVisualsWindow() noexcept
         ImGuiCustom::colorPicker("Sky color", config.visuals.sky);
         ImGui::Combo("VFX", &config.visuals.screenEffect, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
         ImGui::Combo("HitMark", &config.visuals.hitMarker, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
+		ImGui::Checkbox("Hit Damage", &config.visuals.hitMarkerDamageIndicator);
 		ImGui::PushID(14);
+		ImGui::PushItemWidth(280.0f);
         ImGui::SliderFloat(" ", &config.visuals.hitMarkerTime, 0.01f, 1.0f, "Hit marker time: %.2fs");
 		ImGui::PopID();
-		ImGui::Checkbox("Hit Damage", &config.visuals.hitMarkerDamageIndicator);
 		if (config.visuals.hitMarkerDamageIndicator) {
 			ImGui::InputInt("Font", &config.visuals.hitMarkerDamageIndicatorFont, 1, 294);
 			ImGui::InputInt("Alpha", &config.visuals.hitMarkerDamageIndicatorAlpha, 1, 1000);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -752,7 +752,7 @@ void GUI::renderVisualsWindow() noexcept
 		ImGui::Checkbox("Flip ragdoll gravity", &config.visuals.inverseRagdollGravity);
 		if (config.visuals.inverseRagdollGravity) {
 			ImGui::SameLine();
-			ImGui::Checkbox("Custom gravity", &config.visuals.inverseRagdollGravityCustomize);
+			ImGui::Checkbox("Customize gravity", &config.visuals.inverseRagdollGravityCustomize);
 		};
 		if (config.visuals.inverseRagdollGravityCustomize&&config.visuals.inverseRagdollGravity) {
 			ImGui::InputInt("Gravity Value", &config.visuals.inverseRagdollGravityValue, -2400, 2400);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -39,8 +39,8 @@ GUI::GUI() noexcept
         CoTaskMemFree(pathToFonts);
 
         static ImWchar ranges[] = { 0x0020, 0x00FF, 0x0100, 0x017f, 0 };
-        fonts.tahoma = io.Fonts->AddFontFromFileTTF((path / "tahoma.ttf").string().c_str(), 14.0f, nullptr, ranges);
-        fonts.segoeui = io.Fonts->AddFontFromFileTTF((path / "segoeui.ttf").string().c_str(), 14.0f, nullptr, ranges);
+        fonts.tahoma = io.Fonts->AddFontFromFileTTF((path / "tahoma.ttf").string().c_str(), 15.0f, nullptr, ranges);
+        fonts.segoeui = io.Fonts->AddFontFromFileTTF((path / "segoeui.ttf").string().c_str(), 15.0f, nullptr, ranges);
     }
 }
 
@@ -1112,8 +1112,6 @@ void GUI::renderMiscWindow() noexcept
         ImGui::SliderFloat("", &config.misc.maxAngleDelta, 0.0f, 255.0f, "Max angle delta: %.2f");
         ImGui::Checkbox("Fake prime", &config.misc.fakePrime);
         if (ImGui::Button("Unhook"))
-			ImGui::SameLine();
-			if (ImGui::Button("Close Cheat?"))
 				hooks.restore();
 
         ImGui::Columns(1);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -757,7 +757,7 @@ void GUI::renderVisualsWindow() noexcept
 		if (config.visuals.inverseRagdollGravityCustomize&&config.visuals.inverseRagdollGravity) {
 			ImGui::InputInt("Gravity Value", &config.visuals.inverseRagdollGravityValue, -2400, 2400);
 		};
-		ImGui::Checkbox("Custom Viewmodel Position", &config.visuals.customViewmodelToggle);
+		ImGui::Checkbox("Custom Viewmodel", &config.visuals.customViewmodelToggle);
 		if (!config.visuals.customViewmodelToggle) {
 			config.visuals.customViewmodelKnifeEnabled = 0;
 		};

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -772,13 +772,13 @@ void GUI::renderVisualsWindow() noexcept
 			ImGui::SameLine();
 			ImGui::Checkbox("Knife Position", &config.visuals.customViewmodelKnifeToggle);
 			ImGui::PushItemWidth(280.0f);
-			ImGui::PushID(9);
+			ImGui::PushID(1);
 			ImGui::SliderFloat("", &config.visuals.viewmodel_x, -20, 20, "Left/Right: %.2f");
 			ImGui::PopID();
-			ImGui::PushID(8);
+			ImGui::PushID(2);
 			ImGui::SliderFloat("", &config.visuals.viewmodel_y, -20, 20, "Close/Far: %.2f");
 			ImGui::PopID();
-			ImGui::PushID(7);
+			ImGui::PushID(3);
 			ImGui::SliderFloat("", &config.visuals.viewmodel_z, -20, 20, "Down/Up: %.2f");
 			ImGui::PopID();
 			ImGui::Checkbox("Right/Left hand Weapon", &config.visuals.customViewmodelSwitchHand);
@@ -790,13 +790,13 @@ void GUI::renderVisualsWindow() noexcept
 			ImGui::SameLine();
 			ImGui::Checkbox("Knife Position", &config.visuals.customViewmodelKnifeToggle);
 			ImGui::PushItemWidth(280.0f);
-			ImGui::PushID(10);
+			ImGui::PushID(4);
 			ImGui::SliderFloat("", &config.visuals.viewmodel_x_knife, -20, 20, "Left/Right: %.2f");
 			ImGui::PopID();
-			ImGui::PushID(11);
+			ImGui::PushID(5);
 			ImGui::SliderFloat("", &config.visuals.viewmodel_y_knife, -20, 20, "Close/Far: %.2f");
 			ImGui::PopID();
-			ImGui::PushID(12);
+			ImGui::PushID(6);
 			ImGui::SliderFloat("", &config.visuals.viewmodel_z_knife, -20, 20, "Down/Up: %.2f");
 			ImGui::PopID();
 			ImGui::Checkbox("Right/Left hand Knife", &config.visuals.customViewmodelSwitchHandKnife);
@@ -811,28 +811,28 @@ void GUI::renderVisualsWindow() noexcept
         ImGui::SameLine();
         hotkey(config.visuals.thirdpersonKey);
         ImGui::PushItemWidth(280.0f);
-        ImGui::PushID(0);
+        ImGui::PushID(7);
         ImGui::SliderInt("", &config.visuals.thirdpersonDistance, 0, 1000, "Thirdperson distance: %d");
         ImGui::PopID();
-        ImGui::PushID(1);
+        ImGui::PushID(8);
         ImGui::SliderInt("", &config.visuals.viewmodelFov, -60, 60, "Viewmodel FOV: %d");
         ImGui::PopID();
-        ImGui::PushID(2);
+        ImGui::PushID(9);
         ImGui::SliderInt("", &config.visuals.fov, -60, 60, "FOV: %d");
         ImGui::PopID();
-        ImGui::PushID(3);
+        ImGui::PushID(10);
         ImGui::SliderInt("", &config.visuals.farZ, 0, 2000, "Far Z: %d");
         ImGui::PopID();
-        ImGui::PushID(4);
+        ImGui::PushID(11);
         ImGui::SliderInt("", &config.visuals.flashReduction, 0, 100, "Flash reduction: %d%%");
         ImGui::PopID();
 		if (!config.visuals.full_bright) {
-			ImGui::PushID(5);
+			ImGui::PushID(12);
 			ImGui::SliderFloat("", &config.visuals.brightness, 0.0f, 1.0f, "Brightness: %.2f");
 			ImGui::PopID();
 		};
 		if (config.visuals.full_bright) {
-			ImGui::PushID(6);
+			ImGui::PushID(13);
 			ImGui::SliderFloat("", &config.visuals.brightness, 0.0f, 0.0f, "Disabled for Full Bright");
 			ImGui::PopID();
 		};
@@ -844,7 +844,9 @@ void GUI::renderVisualsWindow() noexcept
         ImGuiCustom::colorPicker("Sky color", config.visuals.sky);
         ImGui::Combo("VFX", &config.visuals.screenEffect, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
         ImGui::Combo("HitMark", &config.visuals.hitMarker, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
+		ImGui::PushID(14);
         ImGui::SliderFloat(" ", &config.visuals.hitMarkerTime, 0.01f, 1.0f, "Hit marker time: %.2fs");
+		ImGui::PopID();
 		ImGui::Checkbox("Hit Damage", &config.visuals.hitMarkerDamageIndicator);
 		if (config.visuals.hitMarkerDamageIndicator) {
 			ImGui::InputInt("Font", &config.visuals.hitMarkerDamageIndicatorFont, 1, 294);
@@ -852,7 +854,9 @@ void GUI::renderVisualsWindow() noexcept
 			ImGui::InputInt("Dist", &config.visuals.hitMarkerDamageIndicatorDist, -100, 100);
 			ImGui::InputInt("Text X", &config.visuals.hitMarkerDamageIndicatorTextX, -100, 100);
 			ImGui::InputInt("Text Y", &config.visuals.hitMarkerDamageIndicatorTextY, -100, 100);
+			ImGui::PushID(15);
 			ImGui::SliderFloat("  ", &config.visuals.hitMarkerDamageIndicatorRatio, -1.0f, 1.0f, "Ratio: %.2f");
+			ImGui::PopID();
 		};
 		
         ImGui::Columns(1);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -39,8 +39,8 @@ GUI::GUI() noexcept
         CoTaskMemFree(pathToFonts);
 
         static ImWchar ranges[] = { 0x0020, 0x00FF, 0x0100, 0x017f, 0 };
-        fonts.tahoma = io.Fonts->AddFontFromFileTTF((path / "tahoma.ttf").string().c_str(), 15.0f, nullptr, ranges);
-        fonts.segoeui = io.Fonts->AddFontFromFileTTF((path / "segoeui.ttf").string().c_str(), 15.0f, nullptr, ranges);
+        fonts.tahoma = io.Fonts->AddFontFromFileTTF((path / "tahoma.ttf").string().c_str(), 14.0f, nullptr, ranges);
+        fonts.segoeui = io.Fonts->AddFontFromFileTTF((path / "segoeui.ttf").string().c_str(), 14.0f, nullptr, ranges);
     }
 }
 
@@ -406,12 +406,12 @@ void GUI::renderBacktrackWindow() noexcept
         ImGui::Checkbox("Enabled", &config.backtrack.enabled);
         ImGui::Checkbox("Ignore smoke", &config.backtrack.ignoreSmoke);
         ImGui::Checkbox("Recoil based fov", &config.backtrack.recoilBasedFov);
-		ImGui::Checkbox("pingBased", &config.backtrack.pingBased);
+		ImGui::Checkbox("Draw all ticks", &config.backtrack.drawAllTicks);
+		ImGui::Checkbox("Ping based", &config.backtrack.pingBased);
         ImGui::PushItemWidth(220.0f);
-		if (!config.backtrack.pingBased)
+		if (!config.backtrack.pingBased){
 			ImGui::SliderInt("", &config.backtrack.timeLimit, 1, 200, "Time limit: %d ms");
-			;
-        
+		};
         ImGui::PopItemWidth();
         if (!config.style.menuStyle)
             ImGui::End();
@@ -726,19 +726,19 @@ void GUI::renderVisualsWindow() noexcept
 {
     if (window.visuals) {
         if (!config.style.menuStyle) {
-            ImGui::SetNextWindowSize({ 680.0f, 0.0f });
+            ImGui::SetNextWindowSize({ 576.0f, 0.0f });
             ImGui::Begin("Visuals", &window.visuals, windowFlags);
         }
         ImGui::Columns(2, nullptr, false);
         ImGui::SetColumnOffset(1, 280.0f);
         ImGui::Combo("T Player Model", &config.visuals.playerModelT, "Default\0Special Agent Ava | FBI\0Operator | FBI SWAT\0Markus Delrow | FBI HRT\0Michael Syfers | FBI Sniper\0B Squadron Officer | SAS\0Seal Team 6 Soldier | NSWC SEAL\0Buckshot | NSWC SEAL\0Lt. Commander Ricksaw | NSWC SEAL\0Third Commando Company | KSK\0'Two Times' McCoy | USAF TACP\0Dragomir | Sabre\0Rezan The Ready | Sabre\0'The Doctor' Romanov | Sabre\0Maximus | Sabre\0Blackwolf | Sabre\0The Elite Mr. Muhlik | Elite Crew\0Ground Rebel | Elite Crew\0Osiris | Elite Crew\0Prof. Shahmat | Elite Crew\0Enforcer | Phoenix\0Slingshot | Phoenix\0Soldier | Phoenix\0");
         ImGui::Combo("CT Player Model", &config.visuals.playerModelCT, "Default\0Special Agent Ava | FBI\0Operator | FBI SWAT\0Markus Delrow | FBI HRT\0Michael Syfers | FBI Sniper\0B Squadron Officer | SAS\0Seal Team 6 Soldier | NSWC SEAL\0Buckshot | NSWC SEAL\0Lt. Commander Ricksaw | NSWC SEAL\0Third Commando Company | KSK\0'Two Times' McCoy | USAF TACP\0Dragomir | Sabre\0Rezan The Ready | Sabre\0'The Doctor' Romanov | Sabre\0Maximus | Sabre\0Blackwolf | Sabre\0The Elite Mr. Muhlik | Elite Crew\0Ground Rebel | Elite Crew\0Osiris | Elite Crew\0Prof. Shahmat | Elite Crew\0Enforcer | Phoenix\0Slingshot | Phoenix\0Soldier | Phoenix\0");
-        ImGui::Checkbox("Disable post-processing", &config.visuals.disablePostProcessing);
-        ImGui::Checkbox("Inverse ragdoll gravity", &config.visuals.inverseRagdollGravity);
+        ImGui::Checkbox("Post-processing", &config.visuals.disablePostProcessing);
         ImGui::Checkbox("No fog", &config.visuals.noFog);
         ImGui::Checkbox("No 3d sky", &config.visuals.no3dSky);
         ImGui::Checkbox("No aim punch", &config.visuals.noAimPunch);
         ImGui::Checkbox("No view punch", &config.visuals.noViewPunch);
+		ImGui::Checkbox("No weapon move", &config.visuals.view_bob);
         ImGui::Checkbox("No hands", &config.visuals.noHands);
         ImGui::Checkbox("No sleeves", &config.visuals.noSleeves);
         ImGui::Checkbox("No weapons", &config.visuals.noWeapons);
@@ -748,14 +748,67 @@ void GUI::renderVisualsWindow() noexcept
         ImGui::Checkbox("No grass", &config.visuals.noGrass);
         ImGui::Checkbox("No shadows", &config.visuals.noShadows);
         ImGui::Checkbox("Wireframe smoke", &config.visuals.wireframeSmoke);
+		ImGui::Checkbox("Deagle spinner", &config.visuals.deagleSpinner);
+		ImGui::Checkbox("Flip ragdoll gravity", &config.visuals.inverseRagdollGravity);
+		if (config.visuals.inverseRagdollGravity) {
+			ImGui::SameLine();
+			ImGui::Checkbox("Custom ragdoll gravity", &config.visuals.inverseRagdollGravityCustomize);
+		};
+		if (config.visuals.inverseRagdollGravityCustomize&&config.visuals.inverseRagdollGravity) {
+			ImGui::InputInt("Gravity Value", &config.visuals.inverseRagdollGravityValue, -2400, 2400);
+		};
+		ImGui::Checkbox("Custom Viewmodel Position", &config.visuals.customViewmodelToggle);
+		if (!config.visuals.customViewmodelToggle) {
+			config.visuals.customViewmodelKnifeEnabled = 0;
+		};
+		if (!config.visuals.customViewmodelKnifeToggle) {
+			config.visuals.customViewmodelMenuSwitch = 0;
+		};
+		if (config.visuals.customViewmodelKnifeToggle) {
+			config.visuals.customViewmodelMenuSwitch = 1;
+		};
+		if (config.visuals.customViewmodelToggle && !config.visuals.customViewmodelKnifeToggle && !config.visuals.customViewmodelMenuSwitch) {
+			config.visuals.customViewmodelKnifeEnabled = 1;
+			ImGui::SameLine();
+			ImGui::Checkbox("Knife Position", &config.visuals.customViewmodelKnifeToggle);
+			ImGui::PushItemWidth(280.0f);
+			ImGui::PushID(9);
+			ImGui::SliderFloat("", &config.visuals.viewmodel_x, -20, 20, "Left/Right: %.2f");
+			ImGui::PopID();
+			ImGui::PushID(8);
+			ImGui::SliderFloat("", &config.visuals.viewmodel_y, -20, 20, "Close/Far: %.2f");
+			ImGui::PopID();
+			ImGui::PushID(7);
+			ImGui::SliderFloat("", &config.visuals.viewmodel_z, -20, 20, "Down/Up: %.2f");
+			ImGui::PopID();
+			//if (ImGui::Button("Update Viewmodel"))
+			//	Visuals::customViewmodel();
+		};
+		if (config.visuals.customViewmodelKnifeToggle && config.visuals.customViewmodelMenuSwitch && config.visuals.customViewmodelToggle) {
+			config.visuals.customViewmodelKnifeEnabled = 1;
+			ImGui::SameLine();
+			ImGui::Checkbox("Knife Position", &config.visuals.customViewmodelKnifeToggle);
+			ImGui::PushItemWidth(280.0f);
+			ImGui::PushID(10);
+			ImGui::SliderFloat("", &config.visuals.viewmodel_x_knife, -20, 20, "Left/Right: %.2f");
+			ImGui::PopID();
+			ImGui::PushID(11);
+			ImGui::SliderFloat("", &config.visuals.viewmodel_y_knife, -20, 20, "Close/Far: %.2f");
+			ImGui::PopID();
+			ImGui::PushID(12);
+			ImGui::SliderFloat("", &config.visuals.viewmodel_z_knife, -20, 20, "Down/Up: %.2f");
+			ImGui::PopID();
+		};
+
         ImGui::NextColumn();
         ImGui::Checkbox("Zoom", &config.visuals.zoom);
         ImGui::SameLine();
         hotkey(config.visuals.zoomKey);
+		ImGui::SameLine();
         ImGui::Checkbox("Thirdperson", &config.visuals.thirdperson);
         ImGui::SameLine();
         hotkey(config.visuals.thirdpersonKey);
-        ImGui::PushItemWidth(290.0f);
+        ImGui::PushItemWidth(280.0f);
         ImGui::PushID(0);
         ImGui::SliderInt("", &config.visuals.thirdpersonDistance, 0, 1000, "Thirdperson distance: %d");
         ImGui::PopID();
@@ -771,17 +824,35 @@ void GUI::renderVisualsWindow() noexcept
         ImGui::PushID(4);
         ImGui::SliderInt("", &config.visuals.flashReduction, 0, 100, "Flash reduction: %d%%");
         ImGui::PopID();
-        ImGui::PushID(5);
-        ImGui::SliderFloat("", &config.visuals.brightness, 0.0f, 1.0f, "Brightness: %.2f");
-        ImGui::PopID();
+		if (!config.visuals.full_bright) {
+			ImGui::PushID(5);
+			ImGui::SliderFloat("", &config.visuals.brightness, 0.0f, 1.0f, "Brightness: %.2f");
+			ImGui::PopID();
+		};
+		if (config.visuals.full_bright) {
+			ImGui::PushID(6);
+			ImGui::SliderFloat("", &config.visuals.brightness, 0.0f, 0.0f, "Disabled for Full Bright");
+			ImGui::PopID();
+		};
+		ImGui::Checkbox("Full Bright", &config.visuals.full_bright);
         ImGui::PopItemWidth();
         ImGui::Combo("Skybox", &config.visuals.skybox, "Default\0cs_baggage_skybox_\0cs_tibet\0embassy\0italy\0jungle\0nukeblank\0office\0sky_cs15_daylight01_hdr\0sky_cs15_daylight02_hdr\0sky_cs15_daylight03_hdr\0sky_cs15_daylight04_hdr\0sky_csgo_cloudy01\0sky_csgo_night_flat\0sky_csgo_night02\0sky_day02_05_hdr\0sky_day02_05\0sky_dust\0sky_l4d_rural02_ldr\0sky_venice\0vertigo_hdr\0vertigo\0vertigoblue_hdr\0vietnam\0");
         ImGuiCustom::colorPicker("World color", config.visuals.world);
+		ImGui::SameLine();
         ImGuiCustom::colorPicker("Sky color", config.visuals.sky);
-        ImGui::Checkbox("Deagle spinner", &config.visuals.deagleSpinner);
-        ImGui::Combo("Screen effect", &config.visuals.screenEffect, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
-        ImGui::Combo("Hit marker", &config.visuals.hitMarker, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
-        ImGui::SliderFloat("Hit marker time", &config.visuals.hitMarkerTime, 0.1f, 1.5f, "%.2fs");
+        ImGui::Combo("VFX", &config.visuals.screenEffect, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
+        ImGui::Combo("HitMark", &config.visuals.hitMarker, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
+        ImGui::SliderFloat(" ", &config.visuals.hitMarkerTime, 0.01f, 1.0f, "Hit marker time: %.2fs");
+		ImGui::Checkbox("Hit Damage", &config.visuals.hitMarkerDamageIndicator);
+		if (config.visuals.hitMarkerDamageIndicator) {
+			ImGui::InputInt("Font", &config.visuals.hitMarkerDamageIndicatorFont, 1, 294);
+			ImGui::InputInt("Alpha", &config.visuals.hitMarkerDamageIndicatorAlpha, 1, 1000);
+			ImGui::InputInt("Dist", &config.visuals.hitMarkerDamageIndicatorDist, -100, 100);
+			ImGui::InputInt("Text X", &config.visuals.hitMarkerDamageIndicatorTextX, -100, 100);
+			ImGui::InputInt("Text Y", &config.visuals.hitMarkerDamageIndicatorTextY, -100, 100);
+			ImGui::SliderFloat("  ", &config.visuals.hitMarkerDamageIndicatorRatio, -1.0f, 1.0f, "Ratio: %.2f");
+		};
+		
         ImGui::Columns(1);
 
         if (!config.style.menuStyle)
@@ -952,7 +1023,7 @@ void GUI::renderMiscWindow() noexcept
 {
     if (window.misc) {
         if (!config.style.menuStyle) {
-            ImGui::SetNextWindowSize({ 580.0f, 0.0f });
+            ImGui::SetNextWindowSize({ 500.0f, 0.0f });
             ImGui::Begin("Misc", &window.misc, windowFlags);
         }
         ImGui::Columns(2, nullptr, false);
@@ -984,6 +1055,7 @@ void GUI::renderMiscWindow() noexcept
         ImGui::Checkbox("Fix bone matrix", &config.misc.fixBoneMatrix);
         ImGui::Checkbox("Fix movement", &config.misc.fixMovement);
         ImGui::Checkbox("Disable model occlusion", &config.misc.disableModelOcclusion);
+		ImGui::Checkbox("Fix tablet signal", &config.misc.fixTabletSignal);
         ImGui::NextColumn();
         ImGui::Checkbox("Disable HUD blur", &config.misc.disablePanoramablur);
         ImGui::Checkbox("Animated clan tag", &config.misc.animatedClanTag);
@@ -1017,10 +1089,10 @@ void GUI::renderMiscWindow() noexcept
         ImGui::PushID(4);
         ImGui::InputText("", config.misc.banText, IM_ARRAYSIZE(config.misc.banText));
         ImGui::PopID();
-        ImGui::SameLine();
-        if (ImGui::Button("Setup fake ban"))
-            Misc::fakeBan(true);
         ImGui::Checkbox("Fast plant", &config.misc.fastPlant);
+		ImGui::SameLine();
+		if (ImGui::Button("Setup fake ban"))
+			Misc::fakeBan(true);
         ImGuiCustom::colorPicker("Bomb timer", config.misc.bombTimer);
         ImGui::Checkbox("Quick reload", &config.misc.quickReload);
         ImGui::Checkbox("Prepare revolver", &config.misc.prepareRevolver);
@@ -1036,13 +1108,13 @@ void GUI::renderMiscWindow() noexcept
         ImGui::SameLine();
         hotkey(config.misc.quickHealthshotKey);
         ImGui::Checkbox("Grenade Prediction", &config.misc.nadePredict);
-        ImGui::Checkbox("Fix tablet signal", &config.misc.fixTabletSignal);
-        ImGui::SetNextItemWidth(120.0f);
-        ImGui::SliderFloat("Max angle delta", &config.misc.maxAngleDelta, 0.0f, 255.0f, "%.2f");
+        ImGui::SetNextItemWidth(250.0f);
+        ImGui::SliderFloat("", &config.misc.maxAngleDelta, 0.0f, 255.0f, "Max angle delta: %.2f");
         ImGui::Checkbox("Fake prime", &config.misc.fakePrime);
-
         if (ImGui::Button("Unhook"))
-            hooks.restore();
+			ImGui::SameLine();
+			if (ImGui::Button("Close Cheat?"))
+				hooks.restore();
 
         ImGui::Columns(1);
         if (!config.style.menuStyle)

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -406,9 +406,12 @@ void GUI::renderBacktrackWindow() noexcept
         ImGui::Checkbox("Enabled", &config.backtrack.enabled);
         ImGui::Checkbox("Ignore smoke", &config.backtrack.ignoreSmoke);
         ImGui::Checkbox("Recoil based fov", &config.backtrack.recoilBasedFov);
-		ImGui::Checkbox("Draw all ticks", &config.backtrack.drawAllTicks);
-        ImGui::PushItemWidth(200.0f);
-        ImGui::SliderInt("", &config.backtrack.timeLimit, 1, 200, "Time limit: %d ms");
+		ImGui::Checkbox("pingBased", &config.backtrack.pingBased);
+        ImGui::PushItemWidth(220.0f);
+		if (!config.backtrack.pingBased)
+			ImGui::SliderInt("", &config.backtrack.timeLimit, 1, 200, "Time limit: %d ms");
+			;
+        
         ImGui::PopItemWidth();
         if (!config.style.menuStyle)
             ImGui::End();
@@ -500,6 +503,8 @@ void GUI::renderChamsWindow() noexcept
         ImGui::Combo("Material", &chams.material, "Normal\0Flat\0Animated\0Platinum\0Glass\0Chrome\0Crystal\0Silver\0Gold\0Plastic\0");
         ImGui::Checkbox("Wireframe", &chams.wireframe);
         ImGuiCustom::colorPicker("Color", chams.color.color, nullptr, &chams.color.rainbow, &chams.color.rainbowSpeed);
+        ImGui::SetNextItemWidth(220.0f);
+        ImGui::SliderFloat("Alpha", &chams.alpha, 0.0f, 1.0f, "%.2f");
 
         if (!config.style.menuStyle) {
             ImGui::End();
@@ -633,6 +638,8 @@ void GUI::renderEspWindow() noexcept
                 ImGui::SameLine(spacing);
                 ImGuiCustom::colorPicker("Distance", config.esp.players[selected].distance);
                 ImGuiCustom::colorPicker("Active Weapon", config.esp.players[selected].activeWeapon);
+                ImGui::SameLine(spacing);
+                ImGui::Checkbox("Dead ESP", &config.esp.players[selected].deadesp);
                 ImGui::SliderFloat("Max distance", &config.esp.players[selected].maxDistance, 0.0f, 200.0f, "%.2fm");
                 break;
             }
@@ -719,11 +726,13 @@ void GUI::renderVisualsWindow() noexcept
 {
     if (window.visuals) {
         if (!config.style.menuStyle) {
-            ImGui::SetNextWindowSize({ 520.0f, 0.0f });
+            ImGui::SetNextWindowSize({ 680.0f, 0.0f });
             ImGui::Begin("Visuals", &window.visuals, windowFlags);
         }
         ImGui::Columns(2, nullptr, false);
-        ImGui::SetColumnOffset(1, 210.0f);
+        ImGui::SetColumnOffset(1, 280.0f);
+        ImGui::Combo("T Player Model", &config.visuals.playerModelT, "Default\0Special Agent Ava | FBI\0Operator | FBI SWAT\0Markus Delrow | FBI HRT\0Michael Syfers | FBI Sniper\0B Squadron Officer | SAS\0Seal Team 6 Soldier | NSWC SEAL\0Buckshot | NSWC SEAL\0Lt. Commander Ricksaw | NSWC SEAL\0Third Commando Company | KSK\0'Two Times' McCoy | USAF TACP\0Dragomir | Sabre\0Rezan The Ready | Sabre\0'The Doctor' Romanov | Sabre\0Maximus | Sabre\0Blackwolf | Sabre\0The Elite Mr. Muhlik | Elite Crew\0Ground Rebel | Elite Crew\0Osiris | Elite Crew\0Prof. Shahmat | Elite Crew\0Enforcer | Phoenix\0Slingshot | Phoenix\0Soldier | Phoenix\0");
+        ImGui::Combo("CT Player Model", &config.visuals.playerModelCT, "Default\0Special Agent Ava | FBI\0Operator | FBI SWAT\0Markus Delrow | FBI HRT\0Michael Syfers | FBI Sniper\0B Squadron Officer | SAS\0Seal Team 6 Soldier | NSWC SEAL\0Buckshot | NSWC SEAL\0Lt. Commander Ricksaw | NSWC SEAL\0Third Commando Company | KSK\0'Two Times' McCoy | USAF TACP\0Dragomir | Sabre\0Rezan The Ready | Sabre\0'The Doctor' Romanov | Sabre\0Maximus | Sabre\0Blackwolf | Sabre\0The Elite Mr. Muhlik | Elite Crew\0Ground Rebel | Elite Crew\0Osiris | Elite Crew\0Prof. Shahmat | Elite Crew\0Enforcer | Phoenix\0Slingshot | Phoenix\0Soldier | Phoenix\0");
         ImGui::Checkbox("Disable post-processing", &config.visuals.disablePostProcessing);
         ImGui::Checkbox("Inverse ragdoll gravity", &config.visuals.inverseRagdollGravity);
         ImGui::Checkbox("No fog", &config.visuals.noFog);
@@ -768,10 +777,10 @@ void GUI::renderVisualsWindow() noexcept
         ImGui::PopItemWidth();
         ImGui::Combo("Skybox", &config.visuals.skybox, "Default\0cs_baggage_skybox_\0cs_tibet\0embassy\0italy\0jungle\0nukeblank\0office\0sky_cs15_daylight01_hdr\0sky_cs15_daylight02_hdr\0sky_cs15_daylight03_hdr\0sky_cs15_daylight04_hdr\0sky_csgo_cloudy01\0sky_csgo_night_flat\0sky_csgo_night02\0sky_day02_05_hdr\0sky_day02_05\0sky_dust\0sky_l4d_rural02_ldr\0sky_venice\0vertigo_hdr\0vertigo\0vertigoblue_hdr\0vietnam\0");
         ImGuiCustom::colorPicker("World color", config.visuals.world);
+        ImGuiCustom::colorPicker("Sky color", config.visuals.sky);
         ImGui::Checkbox("Deagle spinner", &config.visuals.deagleSpinner);
         ImGui::Combo("Screen effect", &config.visuals.screenEffect, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
-        ImGui::Combo("Hit marker", &config.visuals.hitMarker, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0Classic Hitmarker\0");
-		ImGui::Checkbox("Hit Damage", &config.visuals.hitMarkerDamageIndicator);
+        ImGui::Combo("Hit marker", &config.visuals.hitMarker, "None\0Drone cam\0Drone cam with noise\0Underwater\0Healthboost\0Dangerzone\0");
         ImGui::SliderFloat("Hit marker time", &config.visuals.hitMarkerTime, 0.1f, 1.5f, "%.2fs");
         ImGui::Columns(1);
 
@@ -957,6 +966,9 @@ void GUI::renderMiscWindow() noexcept
         ImGui::Checkbox("Bunny hop", &config.misc.bunnyHop);
         ImGui::Checkbox("Fast duck", &config.misc.fastDuck);
         ImGui::Checkbox("Moonwalk", &config.misc.moonwalk);
+        ImGui::Checkbox("Slowwalk", &config.misc.slowwalk);
+        ImGui::SameLine();
+        hotkey(config.misc.slowwalkKey);
         ImGui::Checkbox("Sniper crosshair", &config.misc.sniperCrosshair);
         ImGui::Checkbox("Recoil crosshair", &config.misc.recoilCrosshair);
         ImGui::Checkbox("Auto pistol", &config.misc.autoPistol);
@@ -1027,6 +1039,7 @@ void GUI::renderMiscWindow() noexcept
         ImGui::Checkbox("Fix tablet signal", &config.misc.fixTabletSignal);
         ImGui::SetNextItemWidth(120.0f);
         ImGui::SliderFloat("Max angle delta", &config.misc.maxAngleDelta, 0.0f, 255.0f, "%.2f");
+        ImGui::Checkbox("Fake prime", &config.misc.fakePrime);
 
         if (ImGui::Button("Unhook"))
             hooks.restore();

--- a/Osiris/Hacks/Backtrack.cpp
+++ b/Osiris/Hacks/Backtrack.cpp
@@ -43,7 +43,7 @@ void Backtrack::update(FrameStage stage) noexcept
 				config.backtrack.timeLimit = static_cast<int>(latency*1000);
 			
 
-            while (records[i].size() > 3 && records[i].size() > static_cast<size_t>(timeToTicks(static_cast<float>((config.backtrack.timeLimit) / 1000.f) )))
+            while (records[i].size() > 2 && records[i].size() > static_cast<size_t>(timeToTicks(static_cast<float>((config.backtrack.timeLimit) / 1000.f) )))
                 records[i].pop_back();
 
             if (auto invalid = std::find_if(std::cbegin(records[i]), std::cend(records[i]), [](const Record & rec) { return !valid(rec.simulationTime); }); invalid != std::cend(records[i]))
@@ -96,7 +96,7 @@ void Backtrack::run(UserCmd* cmd) noexcept
     }
 
     if (bestTarget) {
-        if (records[bestTargetIndex].size() <= 3 || (!config.backtrack.ignoreSmoke && memory.lineGoesThroughSmoke(localPlayer->getEyePosition(), bestTargetOrigin, 1)))
+        if (records[bestTargetIndex].size() <= 2 || (!config.backtrack.ignoreSmoke && memory.lineGoesThroughSmoke(localPlayer->getEyePosition(), bestTargetOrigin, 1)))
             return;
 
         bestFov = 255.f;

--- a/Osiris/Hacks/Backtrack.cpp
+++ b/Osiris/Hacks/Backtrack.cpp
@@ -43,7 +43,7 @@ void Backtrack::update(FrameStage stage) noexcept
 				config.backtrack.timeLimit = static_cast<int>(latency*1000);
 			
 
-            while (records[i].size() > 2 && records[i].size() > static_cast<size_t>(timeToTicks(static_cast<float>((config.backtrack.timeLimit) / 1000.f) )))
+            while (records[i].size() > 3 && records[i].size() > static_cast<size_t>(timeToTicks(static_cast<float>((config.backtrack.timeLimit) / 1000.f) )))
                 records[i].pop_back();
 
             if (auto invalid = std::find_if(std::cbegin(records[i]), std::cend(records[i]), [](const Record & rec) { return !valid(rec.simulationTime); }); invalid != std::cend(records[i]))
@@ -96,7 +96,7 @@ void Backtrack::run(UserCmd* cmd) noexcept
     }
 
     if (bestTarget) {
-        if (records[bestTargetIndex].size() <= 2 || (!config.backtrack.ignoreSmoke && memory.lineGoesThroughSmoke(localPlayer->getEyePosition(), bestTargetOrigin, 1)))
+        if (records[bestTargetIndex].size() <= 3 || (!config.backtrack.ignoreSmoke && memory.lineGoesThroughSmoke(localPlayer->getEyePosition(), bestTargetOrigin, 1)))
             return;
 
         bestFov = 255.f;

--- a/Osiris/Hacks/Backtrack.cpp
+++ b/Osiris/Hacks/Backtrack.cpp
@@ -20,7 +20,7 @@ void Backtrack::update(FrameStage stage) noexcept
     if (stage == FrameStage::RENDER_START) {
         for (int i = 1; i <= interfaces.engine->getMaxClients(); i++) {
             auto entity = interfaces.entityList->getEntity(i);
-            if (!entity || entity == localPlayer || entity->isDormant() || !entity->isAlive() || !entity->isEnemy()  ) {
+            if (!entity || entity == localPlayer || entity->isDormant() || !entity->isAlive() || !entity->isEnemy()) {
                 records[i].clear();
                 continue;
             }
@@ -36,7 +36,14 @@ void Backtrack::update(FrameStage stage) noexcept
 
             records[i].push_front(record);
 
-            while (records[i].size() > 3 && records[i].size() > static_cast<size_t>(timeToTicks(static_cast<float>(config.backtrack.timeLimit) / 1000.f)))
+			float latency = config.backtrack.pingBasedPing;
+			if (auto networkChannel = interfaces.engine->getNetworkChannel(); networkChannel && networkChannel->getLatency(0) > 0.0f)
+				latency = networkChannel->getLatency(0);
+			if (config.backtrack.pingBased)
+				config.backtrack.timeLimit = static_cast<int>(latency*1000);
+			
+
+            while (records[i].size() > 3 && records[i].size() > static_cast<size_t>(timeToTicks(static_cast<float>((config.backtrack.timeLimit) / 1000.f) )))
                 records[i].pop_back();
 
             if (auto invalid = std::find_if(std::cbegin(records[i]), std::cend(records[i]), [](const Record & rec) { return !valid(rec.simulationTime); }); invalid != std::cend(records[i]))
@@ -68,6 +75,8 @@ void Backtrack::run(UserCmd* cmd) noexcept
     static auto weaponRecoilScale{ interfaces.cvar->findVar("weapon_recoil_scale") };
     const auto aimPunch{ localPlayer->aimPunchAngle() * weaponRecoilScale->getFloat() };
 
+
+
     for (int i = 1; i <= interfaces.engine->getMaxClients(); i++) {
         auto entity = interfaces.entityList->getEntity(i);
         if (!entity || entity == localPlayer || entity->isDormant() || !entity->isAlive()
@@ -87,7 +96,7 @@ void Backtrack::run(UserCmd* cmd) noexcept
     }
 
     if (bestTarget) {
-        if (records[bestTargetIndex].size() <= 12 || (!config.backtrack.ignoreSmoke && memory.lineGoesThroughSmoke(localPlayer->getEyePosition(), bestTargetOrigin, 1)))
+        if (records[bestTargetIndex].size() <= 3 || (!config.backtrack.ignoreSmoke && memory.lineGoesThroughSmoke(localPlayer->getEyePosition(), bestTargetOrigin, 1)))
             return;
 
         bestFov = 255.f;

--- a/Osiris/Hacks/Backtrack.cpp
+++ b/Osiris/Hacks/Backtrack.cpp
@@ -20,7 +20,7 @@ void Backtrack::update(FrameStage stage) noexcept
     if (stage == FrameStage::RENDER_START) {
         for (int i = 1; i <= interfaces.engine->getMaxClients(); i++) {
             auto entity = interfaces.entityList->getEntity(i);
-            if (!entity || entity == localPlayer || entity->isDormant() || !entity->isAlive() || !entity->isEnemy()) {
+            if (!entity || entity == localPlayer || entity->isDormant() || !entity->isAlive() || !entity->isEnemy()  ) {
                 records[i].clear();
                 continue;
             }
@@ -87,7 +87,7 @@ void Backtrack::run(UserCmd* cmd) noexcept
     }
 
     if (bestTarget) {
-        if (records[bestTargetIndex].size() <= 3 || (!config.backtrack.ignoreSmoke && memory.lineGoesThroughSmoke(localPlayer->getEyePosition(), bestTargetOrigin, 1)))
+        if (records[bestTargetIndex].size() <= 12 || (!config.backtrack.ignoreSmoke && memory.lineGoesThroughSmoke(localPlayer->getEyePosition(), bestTargetOrigin, 1)))
             return;
 
         bestFov = 255.f;

--- a/Osiris/Hacks/Chams.cpp
+++ b/Osiris/Hacks/Chams.cpp
@@ -161,15 +161,8 @@ bool Chams::renderPlayers(void* ctx, void* state, const ModelRenderInfo& info, m
                         if (applied)
                             hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, customBoneToWorld);
                         applyChams(config.chams[BACKTRACK].materials[i], false, entity->health());
-                        //hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
-						if (config.backtrack.drawAllTicks) {
-							for (int x = 0; x < record->size(); x++) {
-								hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->at(x).matrix);
-							}
-						}
-						else
-							hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
-						interfaces.modelRender->forceMaterialOverride(nullptr);
+                        hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
+                        interfaces.modelRender->forceMaterialOverride(nullptr);
                         applied = true;
                     }
                 }

--- a/Osiris/Hacks/Chams.cpp
+++ b/Osiris/Hacks/Chams.cpp
@@ -8,6 +8,7 @@
 #include "../SDK/Material.h"
 #include "../SDK/MaterialSystem.h"
 
+
 Chams::Chams() noexcept
 {
     std::ofstream{ "csgo/materials/chamsNormal.vmt" } <<
@@ -161,7 +162,13 @@ bool Chams::renderPlayers(void* ctx, void* state, const ModelRenderInfo& info, m
                         if (applied)
                             hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, customBoneToWorld);
                         applyChams(config.chams[BACKTRACK].materials[i], false, entity->health());
-                        hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
+						if (config.backtrack.drawAllTicks) {
+							for (int x = 0; x < record->size(); x++) {
+								hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->at(x).matrix);
+							}
+						}
+						else
+							hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
                         interfaces.modelRender->forceMaterialOverride(nullptr);
                         applied = true;
                     }

--- a/Osiris/Hacks/Chams.cpp
+++ b/Osiris/Hacks/Chams.cpp
@@ -161,8 +161,15 @@ bool Chams::renderPlayers(void* ctx, void* state, const ModelRenderInfo& info, m
                         if (applied)
                             hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, customBoneToWorld);
                         applyChams(config.chams[BACKTRACK].materials[i], false, entity->health());
-                        hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
-                        interfaces.modelRender->forceMaterialOverride(nullptr);
+                        //hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
+						if (config.backtrack.drawAllTicks) {
+							for (int x = 0; x < record->size(); x++) {
+								hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->at(x).matrix);
+							}
+						}
+						else
+							hooks.modelRender.callOriginal<void, void*, void*, const ModelRenderInfo&, matrix3x4*>(21, ctx, state, info, record->back().matrix);
+						interfaces.modelRender->forceMaterialOverride(nullptr);
                         applied = true;
                     }
                 }

--- a/Osiris/Hacks/Esp.cpp
+++ b/Osiris/Hacks/Esp.cpp
@@ -115,7 +115,7 @@ static auto boundingBox(Entity* entity, BoundingBox& out) noexcept
     return true;
 }
 
-static void renderBox(Entity* entity, const BoundingBox& bbox, const Config::Esp::Shared& config) noexcept
+static void renderBox(const BoundingBox& bbox, const Config::Esp::Shared& config) noexcept
 {
     if (config.box.enabled) {
         if (config.box.rainbow)
@@ -188,7 +188,7 @@ static void renderBox(Entity* entity, const BoundingBox& bbox, const Config::Esp
 static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) noexcept
 {
     if (BoundingBox bbox; boundingBox(entity, bbox)) {
-        renderBox(entity, bbox, config);
+        renderBox(bbox, config);
 
         float drawPositionX = bbox.x0 - 5;
 
@@ -245,7 +245,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
                     else
                         interfaces.surface->setTextColor(config.name.color);
 
-                    interfaces.surface->setTextPosition(bbox.x0 + (fabsf(bbox.x1 - bbox.x0) - width) / 2, bbox.y0 - 5 - height);
+                    interfaces.surface->setTextPosition((bbox.x0 + bbox.x1 - width) / 2, bbox.y0 - 5 - height);
                     interfaces.surface->printText(name);
                 }
             }
@@ -260,7 +260,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
             else
                 interfaces.surface->setTextColor(config.activeWeapon.color);
 
-            interfaces.surface->setTextPosition(bbox.x0 + (bbox.x1 - bbox.x0 - width) * 0.5f, bbox.y1 + 5);
+            interfaces.surface->setTextPosition((bbox.x0 + bbox.x1 - width) / 2, bbox.y1 + 5);
             interfaces.surface->printText(name);
         }     
 
@@ -307,7 +307,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
 static void renderWeaponBox(Entity* entity, const Config::Esp::Weapon& config) noexcept
 {
     if (BoundingBox bbox; boundingBox(entity, bbox)) {
-        renderBox(entity, bbox, config);
+        renderBox(bbox, config);
 
         if (config.name.enabled) {
             const auto name{ interfaces.localize->find(entity->getWeaponData()->name) };
@@ -318,7 +318,7 @@ static void renderWeaponBox(Entity* entity, const Config::Esp::Weapon& config) n
             else
                 interfaces.surface->setTextColor(config.name.color);
 
-            interfaces.surface->setTextPosition(bbox.x0 + (bbox.x1 - bbox.x0 - width) * 0.5f, bbox.y1 + 5);
+            interfaces.surface->setTextPosition((bbox.x0 + bbox.x1 - width) / 2, bbox.y1 + 5);
             interfaces.surface->printText(name);
         }
 
@@ -338,7 +338,7 @@ static void renderWeaponBox(Entity* entity, const Config::Esp::Weapon& config) n
 static void renderEntityBox(Entity* entity, const Config::Esp::Shared& config, const wchar_t* name) noexcept
 {
     if (BoundingBox bbox; boundingBox(entity, bbox)) {
-        renderBox(entity, bbox, config);
+        renderBox(bbox, config);
 
         if (config.name.enabled) {
             const auto [width, height] { interfaces.surface->getTextSize(config.font, name) };
@@ -348,7 +348,7 @@ static void renderEntityBox(Entity* entity, const Config::Esp::Shared& config, c
             else
                 interfaces.surface->setTextColor(config.name.color);
 
-            interfaces.surface->setTextPosition(bbox.x0 + (bbox.x1 - bbox.x0 - width) * 0.5f, bbox.y1 + 5);
+            interfaces.surface->setTextPosition((bbox.x0 + bbox.x1 - width) / 2, bbox.y1 + 5);
             interfaces.surface->printText(name);
         }
 
@@ -398,7 +398,10 @@ static constexpr bool isInRange(Entity* entity, float maxDistance) noexcept
 
 static constexpr bool renderPlayerEsp(Entity* entity, EspId id) noexcept
 {
-    if (config.esp.players[id].enabled && isInRange(entity, config.esp.players[id].maxDistance)) {
+    const auto localPlayer = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer());
+    if ((config.esp.players[id].enabled || 
+        config.esp.players[id].deadesp && !localPlayer->isAlive()) &&
+        isInRange(entity, config.esp.players[id].maxDistance)) {
         renderSnaplines(entity, config.esp.players[id]);
         renderEyeTraces(entity, config.esp.players[id]);
         renderPlayerBox(entity, config.esp.players[id]);
@@ -428,10 +431,15 @@ void Esp::render() noexcept
     if (interfaces.engine->isInGame()) {
         const auto localPlayer = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer());
 
+        if (!localPlayer)
+            return;
+
+        const auto observerTarget = localPlayer->getObserverTarget();
+
         for (int i = 1; i <= interfaces.engine->getMaxClients(); i++) {
             auto entity = interfaces.entityList->getEntity(i);
-            if (!entity || entity == localPlayer || entity->isDormant()
-                || !entity->isAlive())
+            if (!entity || entity == localPlayer || entity == observerTarget
+                || entity->isDormant() || !entity->isAlive())
                 continue;
 
             if (!entity->isEnemy()) {

--- a/Osiris/Hacks/Esp.cpp
+++ b/Osiris/Hacks/Esp.cpp
@@ -245,7 +245,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
                     else
                         interfaces.surface->setTextColor(config.name.color);
 
-                    interfaces.surface->setTextPosition((bbox.x0 + bbox.x1 - width) / 2, bbox.y0 - 5 - height);
+                    interfaces.surface->setTextPosition(bbox.x0 + (fabsf(bbox.x1 - bbox.x0) - width) / 2, bbox.y0 - 5 - height);
                     interfaces.surface->printText(name);
                 }
             }
@@ -260,7 +260,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
             else
                 interfaces.surface->setTextColor(config.activeWeapon.color);
 
-            interfaces.surface->setTextPosition((bbox.x0 + bbox.x1 - width) / 2, bbox.y1 + 5);
+            interfaces.surface->setTextPosition(bbox.x0 + (bbox.x1 - bbox.x0 - width) * 0.5f, bbox.y1 + 5);
             interfaces.surface->printText(name);
         }     
 
@@ -318,7 +318,7 @@ static void renderWeaponBox(Entity* entity, const Config::Esp::Weapon& config) n
             else
                 interfaces.surface->setTextColor(config.name.color);
 
-            interfaces.surface->setTextPosition((bbox.x0 + bbox.x1 - width) / 2, bbox.y1 + 5);
+            interfaces.surface->setTextPosition(bbox.x0 + (bbox.x1 - bbox.x0 - width) * 0.5f, bbox.y1 + 5);
             interfaces.surface->printText(name);
         }
 
@@ -348,7 +348,7 @@ static void renderEntityBox(Entity* entity, const Config::Esp::Shared& config, c
             else
                 interfaces.surface->setTextColor(config.name.color);
 
-            interfaces.surface->setTextPosition((bbox.x0 + bbox.x1 - width) / 2, bbox.y1 + 5);
+            interfaces.surface->setTextPosition(bbox.x0 + (bbox.x1 - bbox.x0 - width) * 0.5f, bbox.y1 + 5);
             interfaces.surface->printText(name);
         }
 
@@ -398,10 +398,7 @@ static constexpr bool isInRange(Entity* entity, float maxDistance) noexcept
 
 static constexpr bool renderPlayerEsp(Entity* entity, EspId id) noexcept
 {
-    const auto localPlayer = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer());
-    if ((config.esp.players[id].enabled || 
-        config.esp.players[id].deadesp && !localPlayer->isAlive()) &&
-        isInRange(entity, config.esp.players[id].maxDistance)) {
+    if (config.esp.players[id].enabled && isInRange(entity, config.esp.players[id].maxDistance)) {
         renderSnaplines(entity, config.esp.players[id]);
         renderEyeTraces(entity, config.esp.players[id]);
         renderPlayerBox(entity, config.esp.players[id]);

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -11,6 +11,11 @@
 #include "../SDK/NetworkChannel.h"
 #include "../SDK/WeaponData.h"
 
+
+
+
+
+
 void Misc::slowwalk(UserCmd* cmd) noexcept
 {
     if (config.misc.slowwalk && GetAsyncKeyState(config.misc.slowwalkKey)) {
@@ -44,7 +49,7 @@ void Misc::slowwalk(UserCmd* cmd) noexcept
 void Misc::inverseRagdollGravity() noexcept
 {
     static auto ragdollGravity = interfaces.cvar->findVar("cl_ragdoll_gravity");
-    ragdollGravity->setValue(config.visuals.inverseRagdollGravity ? -600 : 600);
+    ragdollGravity->setValue(config.visuals.inverseRagdollGravity ? config.visuals.inverseRagdollGravityValue : 600);
 }
 
 void Misc::updateClanTag(bool tagChanged) noexcept
@@ -59,7 +64,7 @@ void Misc::updateClanTag(bool tagChanged) noexcept
         }
 
         static auto lastTime{ 0.0f };
-        if (memory.globalVars->realtime - lastTime < 0.6f) return;
+        if (memory.globalVars->realtime - lastTime < 0.5f) return;
         lastTime = memory.globalVars->realtime;
 
         if (config.misc.animatedClanTag && !clanTag.empty())
@@ -80,10 +85,14 @@ void Misc::updateClanTag(bool tagChanged) noexcept
 void Misc::spectatorList() noexcept
 {
     if (config.misc.spectatorList.enabled && interfaces.engine->isInGame()) {
-        const auto localPlayer = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer());
+		auto localPlayer = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer());
 
-        if (!localPlayer->isAlive())
-            return;
+		if (!localPlayer->isAlive())
+		{
+			if (!localPlayer->getObserverTarget())
+				return;
+			localPlayer = localPlayer->getObserverTarget();
+		}
 
         interfaces.surface->setTextFont(Surface::font);
 

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -11,6 +11,36 @@
 #include "../SDK/NetworkChannel.h"
 #include "../SDK/WeaponData.h"
 
+void Misc::slowwalk(UserCmd* cmd) noexcept
+{
+    if (config.misc.slowwalk && GetAsyncKeyState(config.misc.slowwalkKey)) {
+        const auto localPlayer = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer());
+
+        if (!localPlayer || !localPlayer->isAlive())
+            return;
+
+        const auto activeWeapon = localPlayer->getActiveWeapon();
+        if (!activeWeapon)
+            return;
+
+        const auto weaponData = activeWeapon->getWeaponData();
+        if (!weaponData)
+            return;
+
+        const float maxSpeed = (localPlayer->isScoped() ? weaponData->maxSpeedAlt : weaponData->maxSpeed) / 3;
+
+        if (cmd->forwardmove && cmd->sidemove) {
+            const float maxSpeedRoot = maxSpeed * static_cast<float>(M_SQRT1_2);
+            cmd->forwardmove = cmd->forwardmove < 0.0f ? -maxSpeedRoot : maxSpeedRoot;
+            cmd->sidemove = cmd->sidemove < 0.0f ? -maxSpeedRoot : maxSpeedRoot;
+        } else if (cmd->forwardmove) {
+            cmd->forwardmove = cmd->forwardmove < 0.0f ? -maxSpeed : maxSpeed;
+        } else if (cmd->sidemove) {
+            cmd->sidemove = cmd->sidemove < 0.0f ? -maxSpeed : maxSpeed;
+        }
+    }
+}
+
 void Misc::inverseRagdollGravity() noexcept
 {
     static auto ragdollGravity = interfaces.cvar->findVar("cl_ragdoll_gravity");
@@ -43,7 +73,7 @@ void Misc::updateClanTag(bool tagChanged) noexcept
 
             const auto timeString{ '[' + std::to_string(localTime->tm_hour) + ':' + std::to_string(localTime->tm_min) + ':' + std::to_string(localTime->tm_sec) + ']' };
             memory.setClanTag(timeString.c_str(), timeString.c_str());
-	}
+        }
     }
 }
 
@@ -368,16 +398,16 @@ void Misc::fakeBan(bool set) noexcept
     if (set)
         shouldSet = set;
 
-    if (shouldSet && interfaces.engine->isInGame() && changeName(false, std::string{ "\n" }.append(std::string{ static_cast<char>(config.misc.banColor + 1) }).append(config.misc.banText).append("\x1").c_str(), 5.0f))
+    if (shouldSet && interfaces.engine->isInGame() && changeName(false, std::string{ "\x1\xB" }.append(std::string{ static_cast<char>(config.misc.banColor + 1) }).append(config.misc.banText).append("\x1").c_str(), 5.0f))
         shouldSet = false;
 }
 
 void Misc::nadePredict() noexcept
-{ 
-    static auto nadeVar{ interfaces.cvar->findVar("cl_grenadepreview") }; 
-    
-    nadeVar->onChangeCallbacks.size = 0; 
-    nadeVar->setValue(config.misc.nadePredict); 
+{
+    static auto nadeVar{ interfaces.cvar->findVar("cl_grenadepreview") };
+
+    nadeVar->onChangeCallbacks.size = 0;
+    nadeVar->setValue(config.misc.nadePredict);
 }
 
 void Misc::quickHealthshot(UserCmd* cmd) noexcept
@@ -415,5 +445,20 @@ void Misc::fixTabletSignal() noexcept
 
         if (auto activeWeapon{ localPlayer->getActiveWeapon() }; activeWeapon && activeWeapon->getClientClass()->classId == ClassId::Tablet)
             activeWeapon->tabletReceptionIsBlocked() = false;
+    }
+}
+
+void Misc::fakePrime() noexcept
+{
+    static bool lastState = false;
+
+    if (config.misc.fakePrime != lastState) {
+        lastState = config.misc.fakePrime;
+
+        if (DWORD oldProtect; VirtualProtect(memory.fakePrime, 1, PAGE_EXECUTE_READWRITE, &oldProtect)) {
+            constexpr uint8_t patch[]{ 0x74, 0xEB };
+            *memory.fakePrime = patch[config.misc.fakePrime];
+            VirtualProtect(memory.fakePrime, 1, oldProtect, nullptr);
+        }
     }
 }

--- a/Osiris/Hacks/Misc.h
+++ b/Osiris/Hacks/Misc.h
@@ -11,7 +11,9 @@
 #include "../SDK/GameEvent.h"
 #include "../SDK/GlobalVars.h"
 
-namespace Misc {
+namespace Misc
+{
+    void slowwalk(UserCmd* cmd) noexcept;
     void inverseRagdollGravity() noexcept;
     void updateClanTag(bool = false) noexcept;
     void spectatorList() noexcept;
@@ -31,6 +33,7 @@ namespace Misc {
     void nadePredict() noexcept;
     void quickHealthshot(UserCmd*) noexcept;
     void fixTabletSignal() noexcept;
+    void fakePrime() noexcept;
 
     constexpr void fixMovement(UserCmd* cmd, float yaw) noexcept
     {
@@ -42,8 +45,8 @@ namespace Misc {
 
             const float forwardmove = cmd->forwardmove;
             const float sidemove = cmd->sidemove;
-            cmd->forwardmove = std::clamp(cos(degreesToRadians(yawDelta)) * forwardmove + cos(degreesToRadians(yawDelta + 90.0f)) * sidemove, -450.0f, 450.0f);
-            cmd->sidemove = std::clamp(sin(degreesToRadians(yawDelta)) * forwardmove + sin(degreesToRadians(yawDelta + 90.0f)) * sidemove, -450.0f, 450.0f);
+            cmd->forwardmove = std::cos(degreesToRadians(yawDelta)) * forwardmove + std::cos(degreesToRadians(yawDelta + 90.0f)) * sidemove;
+            cmd->sidemove = std::sin(degreesToRadians(yawDelta)) * forwardmove + std::sin(degreesToRadians(yawDelta + 90.0f)) * sidemove;
         }
     }
 

--- a/Osiris/Hacks/Misc.h
+++ b/Osiris/Hacks/Misc.h
@@ -35,6 +35,8 @@ namespace Misc
     void fixTabletSignal() noexcept;
     void fakePrime() noexcept;
 
+
+
     constexpr void fixMovement(UserCmd* cmd, float yaw) noexcept
     {
         if (config.misc.fixMovement) {

--- a/Osiris/Hacks/SkinChanger.cpp
+++ b/Osiris/Hacks/SkinChanger.cpp
@@ -314,6 +314,7 @@ static void post_data_update_start(Entity* local) noexcept
 
             // Thanks, Beakers
             glove->index() = -1;
+            glove->initialized() = true;
 
             apply_config_on_attributable_item(glove, glove_config, player_info.xuidLow);
         }

--- a/Osiris/Hacks/Visuals.cpp
+++ b/Osiris/Hacks/Visuals.cpp
@@ -10,7 +10,7 @@
 #include "../SDK/Material.h"
 #include "../SDK/MaterialSystem.h"
 #include "../SDK/RenderContext.h"
-
+#include "../SDK/Surface.h"
 void Visuals::colorWorld() noexcept
 {
     if (config.visuals.world.enabled) {
@@ -201,33 +201,118 @@ void Visuals::hitMarker(GameEvent* event) noexcept
         }
 
         if (lastHitTime + config.visuals.hitMarkerTime >= memory.globalVars->realtime) {
-            constexpr auto getEffectMaterial = [] {
-                static constexpr const char* effects[]{
-                "effects/dronecam",
-                "effects/underwater_overlay",
-                "effects/healthboost",
-                "effects/dangerzone_screen"
-                };
+			if (config.visuals.hitMarker > 0 && config.visuals.hitMarker < 6) {
+				constexpr auto getEffectMaterial = [] {
+					static constexpr const char* effects[]{
+					"effects/dronecam",
+					"effects/underwater_overlay",
+					"effects/healthboost",
+					"effects/dangerzone_screen"
+					};
 
-                if (config.visuals.hitMarker <= 2)
-                    return effects[0];
-                return effects[config.visuals.hitMarker - 2];
-            };
+					if (config.visuals.hitMarker <= 2)
+						return effects[0];
+					return effects[config.visuals.hitMarker - 2];
 
-            auto renderContext = interfaces.materialSystem->getRenderContext();
-            renderContext->beginRender();
-            int x, y, width, height;
-            renderContext->getViewport(x, y, width, height);
-            auto material = interfaces.materialSystem->findMaterial(getEffectMaterial());
-            if (config.visuals.hitMarker == 1)
-                material->findVar("$c0_x")->setValue(0.0f);
-            else if (config.visuals.hitMarker == 2)
-                material->findVar("$c0_x")->setValue(0.1f);
-            else if (config.visuals.hitMarker >= 4)
-                material->findVar("$c0_x")->setValue(1.0f);
-            drawScreenEffectMaterial(material, 0, 0, width, height);
-            renderContext->endRender();
-            renderContext->release();
+
+
+
+				};
+
+				auto renderContext = interfaces.materialSystem->getRenderContext();
+				renderContext->beginRender();
+				int x, y, width, height;
+				renderContext->getViewport(x, y, width, height);
+				auto material = interfaces.materialSystem->findMaterial(getEffectMaterial());
+				if (config.visuals.hitMarker == 1)
+					material->findVar("$c0_x")->setValue(0.0f);
+				else if (config.visuals.hitMarker == 2)
+					material->findVar("$c0_x")->setValue(0.1f);
+				else if (config.visuals.hitMarker >= 4)
+					material->findVar("$c0_x")->setValue(1.0f);
+				drawScreenEffectMaterial(material, 0, 0, width, height);
+				renderContext->endRender();
+				renderContext->release();
+			}
+
+			else if (config.visuals.hitMarker == 6) {
+				const auto [screenWidth, screenHeight] = interfaces.surface->getScreenSize();
+
+
+				const auto width_mid = screenWidth		/ 2;
+				const auto height_mid = screenHeight	/ 2;
+
+
+				interfaces.surface->setDrawColor(255, 0, 255, 225);
+
+
+
+				interfaces.surface->drawLine(width_mid - 1, height_mid - -64, width_mid - 1, height_mid + 0);
+				interfaces.surface->drawLine(width_mid - 0, height_mid - -64, width_mid - 0, height_mid + 0);
+				interfaces.surface->drawLine(width_mid + 1, height_mid - -64, width_mid + 1, height_mid + 0);
+				interfaces.surface->drawLine(width_mid + 2, height_mid - -64, width_mid + 2, height_mid + 0);
+				
+				// Right part
+				//interfaces.surface->drawLine(width_mid + 9, height_mid + 10, width_mid + -1, height_mid + 0);
+				///
+				//interfaces.surface->drawLine(width_mid + 9, height_mid + 9, width_mid + 0, height_mid + 0);
+				//interfaces.surface->drawLine(width_mid + 8, height_mid + 10, width_mid + -1, height_mid + 0);
+
+				/// Left Part
+				//interfaces.surface->drawLine(width_mid - 11, height_mid + 10, width_mid - -1, height_mid + 0);
+				///
+				//interfaces.surface->drawLine(width_mid - 11, height_mid + 11, width_mid - -2, height_mid + 0);
+				//interfaces.surface->drawLine(width_mid - 10, height_mid + 11, width_mid - -1, height_mid + 0);
+
+				///
+				/////
+				//interfaces.surface->drawLine(width_mid + 10, height_mid - 10, width_mid + 5, height_mid - 5);
+				//interfaces.surface->drawLine(width_mid - 10, height_mid - 10, width_mid - 5, height_mid - 5);
+			}
+
+
+
         }
     }
+}
+
+void Visuals::hitMarkerSetDamageIndicator(GameEvent* event) noexcept
+{
+	if (config.visuals.hitMarkerDamageIndicator)
+	{
+		if (event && interfaces.engine->getPlayerForUserID(event->getInt("attacker")) == interfaces.engine->getLocalPlayer()) {
+			hitMarkerInfo.push_back({ memory.globalVars->realtime + config.visuals.hitMarkerTime, event->getInt("dmg_health") });
+		}
+	}
+}
+
+void Visuals::hitMarkerDamageIndicator() noexcept
+{
+	if (config.visuals.hitMarkerDamageIndicator)
+	{
+		if (hitMarkerInfo.empty()) return;
+
+		const auto [width, height] = interfaces.surface->getScreenSize();
+
+		for (size_t i = 0; i < hitMarkerInfo.size(); i++)
+		{
+			const auto diff = hitMarkerInfo.at(i).hitMarkerExpTime - memory.globalVars->realtime;
+
+			if (diff < 0.f)
+			{
+				hitMarkerInfo.erase(hitMarkerInfo.begin() + i);
+				continue;
+			}
+
+			const auto dist = 42;
+			const auto ratio = 1.f - diff / .5f;
+			const auto alpha = 255;
+
+			const auto font_id = 91;
+			interfaces.surface->setTextFont(font_id);
+			interfaces.surface->setTextPosition(width / 2 + ratio * dist / 8, height / 2 - 54 + ratio * dist);
+			interfaces.surface->setTextColor(255, 0, 125, alpha);
+			interfaces.surface->printText(std::to_wstring(hitMarkerInfo.at(i).hitMarkerDmg));
+		}
+	}
 }

--- a/Osiris/Hacks/Visuals.cpp
+++ b/Osiris/Hacks/Visuals.cpp
@@ -20,6 +20,8 @@ void Visuals::customViewmodel() noexcept {
 	static ConVar* view_y = interfaces.cvar->findVar("viewmodel_offset_y");
 	static ConVar* view_z = interfaces.cvar->findVar("viewmodel_offset_z");
 	static ConVar* sv_minspec = interfaces.cvar->findVar("sv_competitive_minspec");
+	static ConVar* cl_righthand = interfaces.cvar->findVar("cl_righthand");
+
 	*(int*)((DWORD)& sv_minspec->onChangeCallbacks + 0xC) = 0;
 
 	if (!config.visuals.customViewmodelToggle) {
@@ -28,25 +30,39 @@ void Visuals::customViewmodel() noexcept {
 		view_y->setValue(0);
 		view_z->setValue(0);
 	};
-	if (!config.visuals.customViewmodelToggle) {
-		sv_minspec->setValue(1);
-		view_x->setValue(0);
-		view_y->setValue(0);
-		view_z->setValue(0);
-	};
+
 	if (config.visuals.customViewmodelToggle) {
 		sv_minspec->setValue(0);
-			if (config.visuals.customViewmodelKnifeEnabled&&config.visuals.customViewmodelKnifeOut) {
-				view_x->setValue(config.visuals.viewmodel_x_knife);
-				view_y->setValue(config.visuals.viewmodel_y_knife);
-				view_z->setValue(config.visuals.viewmodel_z_knife);
-			}
-			else{
-				view_x->setValue(config.visuals.viewmodel_x);
-				view_y->setValue(config.visuals.viewmodel_y);
-				view_z->setValue(config.visuals.viewmodel_z);
+
+		if (config.visuals.customViewmodelKnifeEnabled && config.visuals.customViewmodelKnifeOut) {
+			view_x->setValue(config.visuals.viewmodel_x_knife);
+			view_y->setValue(config.visuals.viewmodel_y_knife);
+			view_z->setValue(config.visuals.viewmodel_z_knife);
+
+			if (!config.visuals.customViewmodelSwitchHandKnife) {
+				cl_righthand->setValue(0);
 			};
-	}
+			if (config.visuals.customViewmodelSwitchHandKnife) {
+				cl_righthand->setValue(1);
+			}
+		}
+		else if (config.visuals.customViewmodelBombEquiped) {
+			view_x->setValue(0);
+			view_y->setValue(0);
+			view_z->setValue(0);
+		}
+		else if (!config.visuals.customViewmodelBombEquiped) {
+			view_x->setValue(config.visuals.viewmodel_x);
+			view_y->setValue(config.visuals.viewmodel_y);
+			view_z->setValue(config.visuals.viewmodel_z);
+			if (!config.visuals.customViewmodelSwitchHand) {
+				cl_righthand->setValue(0);
+			};
+			if (config.visuals.customViewmodelSwitchHand) {
+				cl_righthand->setValue(1);
+			}
+		};
+	};
 };
 
 void Visuals::viewBob() noexcept {

--- a/Osiris/Hacks/Visuals.cpp
+++ b/Osiris/Hacks/Visuals.cpp
@@ -29,6 +29,7 @@ void Visuals::customViewmodel() noexcept {
 		view_x->setValue(0);
 		view_y->setValue(0);
 		view_z->setValue(0);
+		cl_righthand->setValue(1);
 	};
 
 	if (config.visuals.customViewmodelToggle) {
@@ -40,10 +41,10 @@ void Visuals::customViewmodel() noexcept {
 			view_z->setValue(config.visuals.viewmodel_z_knife);
 
 			if (!config.visuals.customViewmodelSwitchHandKnife) {
-				cl_righthand->setValue(0);
+				cl_righthand->setValue(1);
 			};
 			if (config.visuals.customViewmodelSwitchHandKnife) {
-				cl_righthand->setValue(1);
+				cl_righthand->setValue(0);
 			}
 		}
 		else if (config.visuals.customViewmodelBombEquiped) {
@@ -56,10 +57,10 @@ void Visuals::customViewmodel() noexcept {
 			view_y->setValue(config.visuals.viewmodel_y);
 			view_z->setValue(config.visuals.viewmodel_z);
 			if (!config.visuals.customViewmodelSwitchHand) {
-				cl_righthand->setValue(0);
+				cl_righthand->setValue(1);
 			};
 			if (config.visuals.customViewmodelSwitchHand) {
-				cl_righthand->setValue(1);
+				cl_righthand->setValue(0);
 			}
 		};
 	};

--- a/Osiris/Hacks/Visuals.h
+++ b/Osiris/Hacks/Visuals.h
@@ -8,16 +8,11 @@
 #include "../SDK/Engine.h"
 #include "../SDK/EntityList.h"
 
-struct HitMarkerInfo {
-	float hitMarkerExpTime;
-	int hitMarkerDmg;
-};
-
-
 enum class FrameStage;
 class GameEvent;
 
 namespace Visuals {
+    void playerModel(FrameStage stage) noexcept;
     void colorWorld() noexcept;
     void modifySmoke() noexcept;
     void thirdperson() noexcept;
@@ -30,8 +25,6 @@ namespace Visuals {
     void applyZoom(FrameStage) noexcept;
     void applyScreenEffects() noexcept;
     void hitMarker(GameEvent* = nullptr) noexcept;
-	void hitMarkerSetDamageIndicator(GameEvent* = nullptr) noexcept;
-	void hitMarkerDamageIndicator() noexcept;
 
     constexpr void disablePostProcessing() noexcept
     {
@@ -70,8 +63,4 @@ namespace Visuals {
         else
             memory.loadSky(interfaces.cvar->findVar("sv_skyname")->string);
     }
-
-
-	inline std::vector<HitMarkerInfo> hitMarkerInfo;
-
 };

--- a/Osiris/Hacks/Visuals.h
+++ b/Osiris/Hacks/Visuals.h
@@ -8,6 +8,12 @@
 #include "../SDK/Engine.h"
 #include "../SDK/EntityList.h"
 
+struct HitMarkerInfo {
+	float hitMarkerExpTime;
+	int hitMarkerDmg;
+};
+
+
 enum class FrameStage;
 class GameEvent;
 
@@ -24,6 +30,8 @@ namespace Visuals {
     void applyZoom(FrameStage) noexcept;
     void applyScreenEffects() noexcept;
     void hitMarker(GameEvent* = nullptr) noexcept;
+	void hitMarkerSetDamageIndicator(GameEvent* = nullptr) noexcept;
+	void hitMarkerDamageIndicator() noexcept;
 
     constexpr void disablePostProcessing() noexcept
     {
@@ -62,4 +70,8 @@ namespace Visuals {
         else
             memory.loadSky(interfaces.cvar->findVar("sv_skyname")->string);
     }
+
+
+	inline std::vector<HitMarkerInfo> hitMarkerInfo;
+
 };

--- a/Osiris/Hacks/Visuals.h
+++ b/Osiris/Hacks/Visuals.h
@@ -8,6 +8,11 @@
 #include "../SDK/Engine.h"
 #include "../SDK/EntityList.h"
 
+struct HitMarkerInfo {
+	float hitMarkerExpTime;
+	int hitMarkerDmg;
+};
+
 enum class FrameStage;
 class GameEvent;
 
@@ -25,6 +30,12 @@ namespace Visuals {
     void applyZoom(FrameStage) noexcept;
     void applyScreenEffects() noexcept;
     void hitMarker(GameEvent* = nullptr) noexcept;
+	void hitMarkerSetDamageIndicator(GameEvent* = nullptr) noexcept;
+	void hitMarkerDamageIndicator() noexcept;
+	void customViewmodel() noexcept;
+	void fullBright() noexcept;
+	void viewBob() noexcept;
+
 
     constexpr void disablePostProcessing() noexcept
     {
@@ -63,4 +74,5 @@ namespace Visuals {
         else
             memory.loadSky(interfaces.cvar->findVar("sv_skyname")->string);
     }
+	inline std::vector<HitMarkerInfo> hitMarkerInfo;
 };

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -220,6 +220,7 @@ static void __stdcall paintTraverse(unsigned int panel, bool forceRepaint, bool 
         Misc::drawBombTimer();
         Misc::spectatorList();
         Misc::watermark();
+		Visuals::hitMarkerDamageIndicator();
     }
     hooks.panel.callOriginal<void, unsigned int, bool, bool>(41, panel, forceRepaint, allowForce);
 }
@@ -322,6 +323,7 @@ static bool __stdcall fireEventClientSide(GameEvent* event) noexcept
     case fnv::hash("player_hurt"):
         Misc::playHitSound(event);
         Visuals::hitMarker(event);
+		Visuals::hitMarkerSetDamageIndicator(event);
         break;
     }
     return hooks.gameEventManager.callOriginal<bool, GameEvent*>(9, event);

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -197,6 +197,10 @@ static float __stdcall getViewModelFov() noexcept
 			config.visuals.customViewmodelKnifeOut = 1;
 		else 
 			config.visuals.customViewmodelKnifeOut = 0;
+		if (const auto activeWeapon = localPlayer->getActiveWeapon(); activeWeapon && activeWeapon->getClientClass()->classId == ClassId::C4)
+			config.visuals.customViewmodelBombEquiped = 1;
+		else
+			config.visuals.customViewmodelBombEquiped = 0;
     }
 
     return hooks.clientMode.callOriginal<float>(35) + additionalFov;

--- a/Osiris/Interfaces.h
+++ b/Osiris/Interfaces.h
@@ -47,11 +47,12 @@ public:
     SoundEmitter* soundEmitter = find<SoundEmitter>(L"soundemittersystem", "VSoundEmitter003");
 private:
     template <typename T>
-    static auto find(const wchar_t* module, const char* name)
+    static auto find(const wchar_t* module, const char* name) noexcept
     {
-        if (const auto createInterface{ reinterpret_cast<std::add_pointer_t<T* (const char* name, int* returnCode)>>(GetProcAddress(GetModuleHandleW(module), "CreateInterface")) })
-            if (T* foundInterface{ createInterface(name, nullptr) })
-                return foundInterface;
+        if (HMODULE moduleHandle = GetModuleHandleW(module))
+            if (const auto createInterface = reinterpret_cast<std::add_pointer_t<T* (const char* name, int* returnCode)>>(GetProcAddress(moduleHandle, "CreateInterface")))
+                if (T* foundInterface = createInterface(name, nullptr))
+                    return foundInterface;
 
         MessageBoxA(nullptr, (std::ostringstream{ } << "Failed to find " << name << " interface!").str().c_str(), "Osiris", MB_OK | MB_ICONERROR);
         std::exit(EXIT_FAILURE);

--- a/Osiris/Memory.cpp
+++ b/Osiris/Memory.cpp
@@ -40,4 +40,6 @@ Memory::Memory() noexcept
     submitReport = findPattern<decltype(submitReport)>(L"client_panorama", "\x55\x8B\xEC\x83\xE4\xF8\x83\xEC\x20\x8B\x4D\x08\x56\x57\xE8????\x8B\xF8\x8D\x4C\x24\x0C");
     test = relativeToAbsolute<uintptr_t>(findPattern<int*>(L"client_panorama", "\xE8????\x3B\x44\x24\x0C", 1)) + 0x71;
     test2 = findPattern<uintptr_t>(L"client_panorama", "\x85\xC0\x0F\x84????\x80\x78\x10\x00\x0F\x84");
+    fakePrime = findPattern<uint8_t*>(L"client_panorama", "\x17\xF6\x40\x14\x10") - 1;
+    debugMsg = reinterpret_cast<decltype(debugMsg)>(GetProcAddress(GetModuleHandleW(L"tier0"), "Msg"));
 }

--- a/Osiris/Memory.h
+++ b/Osiris/Memory.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <sstream>
-#include <string_view>
+#include <type_traits>
 #include <Windows.h>
 #include <Psapi.h>
 
@@ -52,6 +52,8 @@ public:
     std::add_pointer_t<bool __stdcall(const char*, const char*)> submitReport;
     uintptr_t test;
     uintptr_t test2;
+    uint8_t* fakePrime;
+    std::add_pointer_t<void __cdecl(const char* msg, ...)> debugMsg;
 
 private:
     template <typename T = uintptr_t>

--- a/Osiris/Netvars.h
+++ b/Osiris/Netvars.h
@@ -30,18 +30,18 @@ extern Netvars netvars;
 auto funcname() noexcept \
 { \
     constexpr auto hash{ fnv::hash(class_name "->" var_name) }; \
-	return reinterpret_cast<std::add_pointer_t<type>>(this + netvars[hash] + offset); \
+    return reinterpret_cast<std::add_pointer_t<type>>(this + netvars[hash] + offset); \
 }
 
 #define PNETVAR(funcname, class_name, var_name, type) \
-	PNETVAR_OFFSET(funcname, class_name, var_name, 0, type)
+    PNETVAR_OFFSET(funcname, class_name, var_name, 0, type)
 
 #define NETVAR_OFFSET(funcname, class_name, var_name, offset, type) \
 std::add_lvalue_reference_t<type> funcname() noexcept \
 { \
     constexpr auto hash{ fnv::hash(class_name "->" var_name) }; \
-	return *reinterpret_cast<std::add_pointer_t<type>>(this + netvars[hash] + offset); \
+    return *reinterpret_cast<std::add_pointer_t<type>>(this + netvars[hash] + offset); \
 }
 
 #define NETVAR(funcname, class_name, var_name, type) \
-	NETVAR_OFFSET(funcname, class_name, var_name, 0, type)
+    NETVAR_OFFSET(funcname, class_name, var_name, 0, type)

--- a/Osiris/Osiris.vcxproj
+++ b/Osiris/Osiris.vcxproj
@@ -159,6 +159,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
+    <TargetName>shroud</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Osiris/Osiris.vcxproj
+++ b/Osiris/Osiris.vcxproj
@@ -159,7 +159,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
-    <TargetName>shroud</TargetName>
+    <TargetName>osiris</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Osiris/Osiris.vcxproj
+++ b/Osiris/Osiris.vcxproj
@@ -159,7 +159,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
-    <TargetName>shroud</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Osiris/SDK/Entity.h
+++ b/Osiris/SDK/Entity.h
@@ -97,9 +97,9 @@ public:
             return Vector{ };
     }
 
-    constexpr Vector getEyePosition() noexcept
+    auto getEyePosition() noexcept
     {
-        Vector vec{ };
+        Vector vec;
         callVirtualMethod<void, Vector&>(this, 284, vec);
         return vec;
     }
@@ -225,73 +225,75 @@ public:
         return *reinterpret_cast<matrix3x4*>(this + 0x444);
     }
 
-    NETVAR_OFFSET(index, "CBaseEntity", "m_bIsAutoaimTarget", 4, int);
-    NETVAR(modelIndex, "CBaseEntity", "m_nModelIndex", unsigned);
-    NETVAR(origin, "CBaseEntity", "m_vecOrigin", Vector);
-    NETVAR_OFFSET(moveType, "CBaseEntity", "m_nRenderMode", 1, MoveType);
-    NETVAR(simulationTime, "CBaseEntity", "m_flSimulationTime", float);
-    NETVAR(ownerEntity, "CBaseEntity", "m_hOwnerEntity", int);
+    NETVAR_OFFSET(index, "CBaseEntity", "m_bIsAutoaimTarget", 4, int)
+    NETVAR(modelIndex, "CBaseEntity", "m_nModelIndex", unsigned)
+    NETVAR(origin, "CBaseEntity", "m_vecOrigin", Vector)
+    NETVAR_OFFSET(moveType, "CBaseEntity", "m_nRenderMode", 1, MoveType)
+    NETVAR(simulationTime, "CBaseEntity", "m_flSimulationTime", float)
+    NETVAR(ownerEntity, "CBaseEntity", "m_hOwnerEntity", int)
+    NETVAR(team, "CBaseEntity", "m_iTeamNum", int)
 
-    NETVAR(weapons, "CBaseCombatCharacter", "m_hMyWeapons", int[48]);
-    PNETVAR(wearables, "CBaseCombatCharacter", "m_hMyWearables", int);
+    NETVAR(weapons, "CBaseCombatCharacter", "m_hMyWeapons", int[48])
+    PNETVAR(wearables, "CBaseCombatCharacter", "m_hMyWearables", int)
 
-    NETVAR(viewModel, "CBasePlayer", "m_hViewModel[0]", int);
-    NETVAR(health, "CBasePlayer", "m_iHealth", int);
-    NETVAR(fov, "CBasePlayer", "m_iFOV", int);
-    NETVAR(fovStart, "CBasePlayer", "m_iFOVStart", int);
-    NETVAR(flags, "CBasePlayer", "m_fFlags", int);
-    NETVAR(tickBase, "CBasePlayer", "m_nTickBase", int);
-    NETVAR(aimPunchAngle, "CBasePlayer", "m_aimPunchAngle", Vector);
-    NETVAR(viewPunchAngle, "CBasePlayer", "m_viewPunchAngle", Vector);
-    NETVAR(velocity, "CBasePlayer", "m_vecVelocity[0]", Vector);
+    NETVAR(viewModel, "CBasePlayer", "m_hViewModel[0]", int)
+    NETVAR(health, "CBasePlayer", "m_iHealth", int)
+    NETVAR(fov, "CBasePlayer", "m_iFOV", int)
+    NETVAR(fovStart, "CBasePlayer", "m_iFOVStart", int)
+    NETVAR(flags, "CBasePlayer", "m_fFlags", int)
+    NETVAR(tickBase, "CBasePlayer", "m_nTickBase", int)
+    NETVAR(aimPunchAngle, "CBasePlayer", "m_aimPunchAngle", Vector)
+    NETVAR(viewPunchAngle, "CBasePlayer", "m_viewPunchAngle", Vector)
+    NETVAR(velocity, "CBasePlayer", "m_vecVelocity[0]", Vector)
     
-    NETVAR(armor, "CCSPlayer", "m_ArmorValue", int);
-    NETVAR(eyeAngles, "CCSPlayer", "m_angEyeAngles", Vector);
-    NETVAR(isScoped, "CCSPlayer", "m_bIsScoped", bool);
-    NETVAR(isDefusing, "CCSPlayer", "m_bIsDefusing", bool);
-    NETVAR(flashDuration, "CCSPlayer", "m_flFlashDuration", float);
-    NETVAR(flashMaxAlpha, "CCSPlayer", "m_flFlashMaxAlpha", float);
-    NETVAR(gunGameImmunity, "CCSPlayer", "m_bGunGameImmunity", bool);
-    NETVAR(account, "CCSPlayer", "m_iAccount", int);
-    NETVAR(inBombZone, "CCSPlayer", "m_bInBombZone", bool);
+    NETVAR(armor, "CCSPlayer", "m_ArmorValue", int)
+    NETVAR(eyeAngles, "CCSPlayer", "m_angEyeAngles", Vector)
+    NETVAR(isScoped, "CCSPlayer", "m_bIsScoped", bool)
+    NETVAR(isDefusing, "CCSPlayer", "m_bIsDefusing", bool)
+    NETVAR(flashDuration, "CCSPlayer", "m_flFlashDuration", float)
+    NETVAR(flashMaxAlpha, "CCSPlayer", "m_flFlashMaxAlpha", float)
+    NETVAR(gunGameImmunity, "CCSPlayer", "m_bGunGameImmunity", bool)
+    NETVAR(account, "CCSPlayer", "m_iAccount", int)
+    NETVAR(inBombZone, "CCSPlayer", "m_bInBombZone", bool)
     NETVAR(hasDefuser, "CCSPlayer", "m_bHasDefuser", bool)
-    NETVAR(hasHelmet, "CCSPlayer", "m_bHasHelmet", bool);
-    NETVAR(lby, "CCSPlayer", "m_flLowerBodyYawTarget", float);
+    NETVAR(hasHelmet, "CCSPlayer", "m_bHasHelmet", bool)
+    NETVAR(lby, "CCSPlayer", "m_flLowerBodyYawTarget", float)
 
-    NETVAR(viewModelIndex, "CBaseCombatWeapon", "m_iViewModelIndex", int);
-    NETVAR(worldModelIndex, "CBaseCombatWeapon", "m_iWorldModelIndex", int);
-    NETVAR(worldDroppedModelIndex, "CBaseCombatWeapon", "m_iWorldDroppedModelIndex", int);
-    NETVAR(weaponWorldModel, "CBaseCombatWeapon", "m_hWeaponWorldModel", int);
-    NETVAR(clip, "CBaseCombatWeapon", "m_iClip1", int);
-    NETVAR(nextPrimaryAttack, "CBaseCombatWeapon", "m_flNextPrimaryAttack", float);
+    NETVAR(viewModelIndex, "CBaseCombatWeapon", "m_iViewModelIndex", int)
+    NETVAR(worldModelIndex, "CBaseCombatWeapon", "m_iWorldModelIndex", int)
+    NETVAR(worldDroppedModelIndex, "CBaseCombatWeapon", "m_iWorldDroppedModelIndex", int)
+    NETVAR(weaponWorldModel, "CBaseCombatWeapon", "m_hWeaponWorldModel", int)
+    NETVAR(clip, "CBaseCombatWeapon", "m_iClip1", int)
+    NETVAR(nextPrimaryAttack, "CBaseCombatWeapon", "m_flNextPrimaryAttack", float)
 
-    NETVAR(nextAttack, "CBaseCombatCharacter", "m_flNextAttack", float);
+    NETVAR(nextAttack, "CBaseCombatCharacter", "m_flNextAttack", float)
 
-    NETVAR(accountID, "CBaseAttributableItem", "m_iAccountID", int);
-    NETVAR(itemDefinitionIndex, "CBaseAttributableItem", "m_iItemDefinitionIndex", short);
-    NETVAR(itemDefinitionIndex2, "CBaseAttributableItem", "m_iItemDefinitionIndex", WeaponId);
-    NETVAR(itemIDHigh, "CBaseAttributableItem", "m_iItemIDHigh", int);
-    NETVAR(entityQuality, "CBaseAttributableItem", "m_iEntityQuality", int);
-    NETVAR(customName, "CBaseAttributableItem", "m_szCustomName", char[32]);
-    NETVAR(fallbackPaintKit, "CBaseAttributableItem", "m_nFallbackPaintKit", unsigned);
-    NETVAR(fallbackSeed, "CBaseAttributableItem", "m_nFallbackSeed", unsigned);
-    NETVAR(fallbackWear, "CBaseAttributableItem", "m_flFallbackWear", float);
-    NETVAR(fallbackStatTrak, "CBaseAttributableItem", "m_nFallbackStatTrak", unsigned);
+    NETVAR(accountID, "CBaseAttributableItem", "m_iAccountID", int)
+    NETVAR(itemDefinitionIndex, "CBaseAttributableItem", "m_iItemDefinitionIndex", short)
+    NETVAR(itemDefinitionIndex2, "CBaseAttributableItem", "m_iItemDefinitionIndex", WeaponId)
+    NETVAR(itemIDHigh, "CBaseAttributableItem", "m_iItemIDHigh", int)
+    NETVAR(entityQuality, "CBaseAttributableItem", "m_iEntityQuality", int)
+    NETVAR(customName, "CBaseAttributableItem", "m_szCustomName", char[32])
+    NETVAR(fallbackPaintKit, "CBaseAttributableItem", "m_nFallbackPaintKit", unsigned)
+    NETVAR(fallbackSeed, "CBaseAttributableItem", "m_nFallbackSeed", unsigned)
+    NETVAR(fallbackWear, "CBaseAttributableItem", "m_flFallbackWear", float)
+    NETVAR(fallbackStatTrak, "CBaseAttributableItem", "m_nFallbackStatTrak", unsigned)
+    NETVAR(initialized, "CBaseAttributableItem", "m_bInitialized", bool)
 
-    NETVAR(owner, "CBaseViewModel", "m_hOwner", int);
-    NETVAR(weapon, "CBaseViewModel", "m_hWeapon", int);
+    NETVAR(owner, "CBaseViewModel", "m_hOwner", int)
+    NETVAR(weapon, "CBaseViewModel", "m_hWeapon", int)
 
-    NETVAR(c4StartedArming, "CC4", "m_bStartedArming", bool);
+    NETVAR(c4StartedArming, "CC4", "m_bStartedArming", bool)
 
-    NETVAR(c4BlowTime, "CPlantedC4", "m_flC4Blow", float);
-    NETVAR(c4BombSite, "CPlantedC4", "m_nBombSite", int);
-    NETVAR(c4Ticking, "CPlantedC4", "m_bBombTicking", bool);
-    NETVAR(c4DefuseCountDown, "CPlantedC4", "m_flDefuseCountDown", float);
-    NETVAR(c4Defuser, "CPlantedC4", "m_hBombDefuser", int);
+    NETVAR(c4BlowTime, "CPlantedC4", "m_flC4Blow", float)
+    NETVAR(c4BombSite, "CPlantedC4", "m_nBombSite", int)
+    NETVAR(c4Ticking, "CPlantedC4", "m_bBombTicking", bool)
+    NETVAR(c4DefuseCountDown, "CPlantedC4", "m_flDefuseCountDown", float)
+    NETVAR(c4Defuser, "CPlantedC4", "m_hBombDefuser", int)
 
-    NETVAR(tabletReceptionIsBlocked, "CTablet", "m_bTabletReceptionIsBlocked", bool);
+    NETVAR(tabletReceptionIsBlocked, "CTablet", "m_bTabletReceptionIsBlocked", bool)
     
-    NETVAR(droneTarget, "CDrone", "m_hMoveToThisEntity", int);
+    NETVAR(droneTarget, "CDrone", "m_hMoveToThisEntity", int)
 
-    NETVAR(sentryHealth, "CDronegun", "m_iHealth", int);
+    NETVAR(sentryHealth, "CDronegun", "m_iHealth", int)
 };

--- a/Osiris/SDK/Entity.h
+++ b/Osiris/SDK/Entity.h
@@ -258,6 +258,7 @@ public:
     NETVAR(hasDefuser, "CCSPlayer", "m_bHasDefuser", bool)
     NETVAR(hasHelmet, "CCSPlayer", "m_bHasHelmet", bool)
     NETVAR(lby, "CCSPlayer", "m_flLowerBodyYawTarget", float)
+	NETVAR(ragdoll, "CCSPlayer", "m_hRagdoll", int)
 
     NETVAR(viewModelIndex, "CBaseCombatWeapon", "m_iViewModelIndex", int)
     NETVAR(worldModelIndex, "CBaseCombatWeapon", "m_iWorldModelIndex", int)

--- a/Osiris/SDK/Material.h
+++ b/Osiris/SDK/Material.h
@@ -2,6 +2,8 @@
 
 #include "Utils.h"
 
+#include <tuple>
+
 class MaterialVar {
 public:
     constexpr auto setValue(float value) noexcept
@@ -47,6 +49,11 @@ public:
     constexpr void colorModulate(float r, float g, float b) noexcept
     {
         callVirtualMethod<void, float, float, float>(this, 28, r, g, b);
+    }
+
+    constexpr void colorModulate(const std::tuple<float, float, float>& color) noexcept
+    {
+        callVirtualMethod<void, float, float, float>(this, 28, std::get<0>(color), std::get<1>(color), std::get<2>(color));
     }
 
     constexpr void setMaterialVarFlag(MaterialVarFlag flag, bool on) noexcept

--- a/Osiris/SDK/ModelInfo.h
+++ b/Osiris/SDK/ModelInfo.h
@@ -1,6 +1,28 @@
 #pragma once
 
 #include "Utils.h"
+#include "Vector.h"
+
+struct StudioHdr {
+    int id;
+    int version;
+    int checksum;
+    char name[64];
+    int length;
+    Vector eyePosition;
+    Vector illumPosition;
+    Vector hullMin;
+    Vector hullMax;
+    Vector bbMin;
+    Vector bbMax;
+    int flags;
+    int numBones;
+    int boneIndex;
+    int numBoneControllers;
+    int boneControllerIndex;
+    int numHitboxSets;
+    int hitboxSetIndex;
+};
 
 class ModelInfo {
 public:

--- a/Osiris/SDK/WeaponData.h
+++ b/Osiris/SDK/WeaponData.h
@@ -20,5 +20,8 @@ struct WeaponData {
     float range;
     float rangeModifier;
     std::byte pad5[16];
-    bool hasSilencer;
+    bool silencer;
+    std::byte pad6[15];
+    float maxSpeed;
+    float maxSpeedAlt;
 };

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Free open-source training software / cheat for **Counter-Strike: Global Offensiv
 ### Prerequisites
 Microsoft Visual Studio 2019 (preferably the latest version), platform toolset v142 and Windows SDK 10.0 are required in order to compile Osiris. If you don't have ones, you can download VS [here](https://visualstudio.microsoft.com/) (Windows SDK is installed during Visual Studio Setup).
 
-### Dowloading
+### Downloading
 
 There are two options of downloading the source code:
 
@@ -206,7 +206,7 @@ To download source code this way [click here](https://github.com/danielkrupinski
 
 #### With [git](https://git-scm.com)
 
-Choose this option if you're going to contribute to the repo or you want to use version control system. Download size ~100 MB (because of full commit history). Git is required to step futher, if not installed download it [here](https://git-scm.com).
+Choose this option if you're going to contribute to the repo or you want to use version control system. Download size ~100 MB (because of full commit history). Git is required to step further, if not installed download it [here](https://git-scm.com).
 
 Open git command prompt and enter following command:
 ```
@@ -255,3 +255,4 @@ This project is licensed under the [MIT License](https://opensource.org/licenses
 
 ## See also
 - [Anubis](https://github.com/danielkrupinski/Anubis) - free and open source cheat for CS:GO with configuration compatible with Osiris
+- [GOESP](https://github.com/danielkrupinski/GOESP) - free and open source stream-proof ESP hack for Counter-Strike: Global Offensive, written in modern C++


### PR DESCRIPTION
Updated to commit  3,476 // Fix game window not restoring after pressing Win + D with GUI open

To see all changes check https://github.com/danielkrupinski/Osiris/compare/master...RyDeem:master

Changed visuals window and added features.

Thank you coders!
#835 By ZerGo0 // Hitmarker Damage Indicator
#894 By agshaidun // Spec List on other players
#730 By JDeu // Draw All Backtrack Tick Chams
#584 By effex1337 // View Model Offset XYZ (I added knife position indipendent as well)
Also added:
Fullbright
No weapon sway on movement
Ragdoll gravity customize
Hit Damage menu integration (still WiP so not perfect as i dont really understand where ZerGo0's code calls for the damage text movement direction.)
cl_righthand in visuals menu for weapons or knife independent of eachother.
weapon position xyz resets on bomb equip to default 000, and back to your weapon/knife values on switch. (no toggle, just on, i can make togglable if needed)

Check the Visuals menu ingame! 💃 