### PR TITLE
Added mat_fullbright setting in visuals window

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -670,6 +670,7 @@ void Config::load(size_t id) noexcept
         if (visualsJson.isMember("farZ")) visuals.farZ = visualsJson["farZ"].asInt();
         if (visualsJson.isMember("flashReduction")) visuals.flashReduction = visualsJson["flashReduction"].asInt();
         if (visualsJson.isMember("brightness")) visuals.brightness = visualsJson["brightness"].asFloat();
+		if (visualsJson.isMember("fullBright")) visuals.fullBright = visualsJson["fullBright"].asBool();
         if (visualsJson.isMember("skybox")) visuals.skybox = visualsJson["skybox"].asInt();
         if (visualsJson.isMember("World")) {
             const auto& worldJson = visualsJson["World"];
@@ -1424,6 +1425,7 @@ void Config::save(size_t id) const noexcept
         visualsJson["farZ"] = visuals.farZ;
         visualsJson["flashReduction"] = visuals.flashReduction;
         visualsJson["brightness"] = visuals.brightness;
+		visualsJson["fullBright"] = visuals.fullBright;
         visualsJson["skybox"] = visuals.skybox;
 
         {

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -175,6 +175,7 @@ public:
         int farZ{ 0 };
         int flashReduction{ 0 };
         float brightness{ 0.0f };
+		bool fullBright{ 0 };
         int skybox{ 0 };
         ColorToggle world;
         ColorToggle sky;

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -767,10 +767,18 @@ void GUI::renderVisualsWindow() noexcept
         ImGui::PushID(4);
         ImGui::SliderInt("", &config.visuals.flashReduction, 0, 100, "Flash reduction: %d%%");
         ImGui::PopID();
-        ImGui::PushID(5);
-        ImGui::SliderFloat("", &config.visuals.brightness, 0.0f, 1.0f, "Brightness: %.2f");
-        ImGui::PopID();
+		if (!config.visuals.fullBright) {
+			ImGui::PushID(6);
+			ImGui::SliderFloat("", &config.visuals.brightness, 0.0f, 1.0f, "Brightness: %.2f");
+			ImGui::PopID();
+		};
+		if (config.visuals.fullBright) {
+			ImGui::PushID(7);
+			ImGui::SliderFloat("", &config.visuals.brightness, 0.0f, 0.0f, "Disabled for Full Bright");
+			ImGui::PopID();
+		};
         ImGui::PopItemWidth();
+		ImGui::Checkbox("Full Bright", &config.visuals.fullBright);
         ImGui::Combo("Skybox", &config.visuals.skybox, "Default\0cs_baggage_skybox_\0cs_tibet\0embassy\0italy\0jungle\0nukeblank\0office\0sky_cs15_daylight01_hdr\0sky_cs15_daylight02_hdr\0sky_cs15_daylight03_hdr\0sky_cs15_daylight04_hdr\0sky_csgo_cloudy01\0sky_csgo_night_flat\0sky_csgo_night02\0sky_day02_05_hdr\0sky_day02_05\0sky_dust\0sky_l4d_rural02_ldr\0sky_venice\0vertigo_hdr\0vertigo\0vertigoblue_hdr\0vietnam\0");
         ImGuiCustom::colorPicker("World color", config.visuals.world);
         ImGuiCustom::colorPicker("Sky color", config.visuals.sky);

--- a/Osiris/Hacks/Visuals.cpp
+++ b/Osiris/Hacks/Visuals.cpp
@@ -14,6 +14,22 @@
 
 #include <array>
 
+void Visuals::fullBright() noexcept {
+
+	const auto localPlayer = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer());
+	if (!localPlayer)
+		return;
+
+	static ConVar* full_bright = interfaces.cvar->findVar("mat_fullbright");
+
+	if (!config.visuals.fullBright) {
+		full_bright->setValue(config.visuals.fullBright ? 0 : 0);
+	};
+	if (config.visuals.fullBright) {
+		full_bright->setValue(config.visuals.fullBright ? 1 : 0);
+	};
+};
+
 void Visuals::playerModel(FrameStage stage) noexcept
 {
     if (stage != FrameStage::NET_UPDATE_POSTDATAUPDATE_START)

--- a/Osiris/Hacks/Visuals.h
+++ b/Osiris/Hacks/Visuals.h
@@ -12,6 +12,7 @@ enum class FrameStage;
 class GameEvent;
 
 namespace Visuals {
+	void fullBright() noexcept;
     void playerModel(FrameStage stage) noexcept;
     void colorWorld() noexcept;
     void modifySmoke() noexcept;

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -139,6 +139,7 @@ static bool __stdcall createMove(float inputSampleTime, UserCmd* cmd) noexcept
     Misc::fixTabletSignal();
     Misc::slowwalk(cmd);
     Misc::edgejump(cmd);
+	Visuals::fullBright();
 
     if (!(cmd->buttons & (UserCmd::IN_ATTACK | UserCmd::IN_ATTACK2))) {
         Misc::chokePackets(sendPacket);


### PR DESCRIPTION
-added a mat_fullbright switch in visuals menu, and when enabled it also disables brightness slider with a notification on the slider. (because the slider does nothing anyway when mat_fullbright = 1)

-hooked it in createMove

-Added config save/load for it

game looks sweet with mat_fullbright on, a must have feature ;D 