### PR TITLE
Recoil crosshair for scoped AUG and SG553

### DIFF
--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -146,6 +146,11 @@ void Misc::sniperCrosshair() noexcept
 
 void Misc::recoilCrosshair() noexcept
 {
+	const auto localPlayer = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer());
+
+        if (!localPlayer->isAlive())
+            return;
+	
 	if (config.misc.recoilCrosshair)
 	{
 		static auto recoilCrosshair = interfaces.cvar->findVar("cl_crosshair_recoil");

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -141,13 +141,24 @@ void Misc::spectatorList() noexcept
 void Misc::sniperCrosshair() noexcept
 {
     static auto showSpread = interfaces.cvar->findVar("weapon_debug_spread_show");
-    showSpread->setValue(config.misc.sniperCrosshair && !interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer())->isScoped() ? 3 : 0);
+    showSpread->setValue(config.misc.sniperCrosshair ? 3 : 0);  //should we check for flags in_zoom 1 << 19 ?
 }
 
 void Misc::recoilCrosshair() noexcept
 {
-    static auto recoilCrosshair = interfaces.cvar->findVar("cl_crosshair_recoil");
-    recoilCrosshair->setValue(config.misc.recoilCrosshair ? 1 : 0);
+	if (config.misc.recoilCrosshair)
+	{
+		static auto recoilCrosshair = interfaces.cvar->findVar("cl_crosshair_recoil");
+		const auto activeWeapon = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer())->getActiveWeapon();
+		if (activeWeapon->isNoRcs())
+		{
+			recoilCrosshair->setValue(0);
+		}
+		else
+		{
+			recoilCrosshair->setValue(1);
+		}
+	}
 }
 
 void Misc::watermark() noexcept

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -147,7 +147,8 @@ void Misc::sniperCrosshair() noexcept
 void Misc::recoilCrosshair() noexcept
 {
 	const auto localPlayer = interfaces.entityList->getEntity(interfaces.engine->getLocalPlayer());
-
+	if(!localPlayer)
+	    return;
         if (!localPlayer->isAlive())
             return;
 	

--- a/Osiris/SDK/Entity.h
+++ b/Osiris/SDK/Entity.h
@@ -55,6 +55,22 @@ public:
         }
     }
 
+    	constexpr bool isNoRcs() noexcept
+	{
+		switch (getClientClass()->classId) {
+		case ClassId::Deagle:
+		case ClassId::Glock:
+		case ClassId::P2000:
+		case ClassId::P250:
+		case ClassId::Tec9:
+		case ClassId::Ssg08:
+		case ClassId::Awp:
+			return true;
+		default:
+			return false;
+		}
+	}
+    
     constexpr bool isSniperRifle() noexcept
     {
         switch (getClientClass()->classId) {


### PR DESCRIPTION
For some reason netvar IsScoped is not contain AUG and SG553, 

 ![After](https://i.imgur.com/q4YIbBg.png)