### PR TITLE
Friendly fire/team damage counter

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -153,7 +153,7 @@ void Config::load(size_t id) noexcept
     for (size_t i = 0; i < esp.players.size(); i++) {
         const auto& espJson = json["Esp"]["Players"][i];
         auto& espConfig = esp.players[i];
-        
+
         if (espJson.isMember("Enabled")) espConfig.enabled = espJson["Enabled"].asBool();
         if (espJson.isMember("Font")) espConfig.font = espJson["Font"].asInt();
 
@@ -366,7 +366,7 @@ void Config::load(size_t id) noexcept
             if (distanceJson.isMember("Rainbow")) distanceConfig.rainbow = distanceJson["Rainbow"].asBool();
             if (distanceJson.isMember("Rainbow speed")) distanceConfig.rainbowSpeed = distanceJson["Rainbow speed"].asFloat();
         }
-        
+
         if (espJson.isMember("Dead ESP")) espConfig.deadesp = espJson["Dead ESP"].asBool();
         if (espJson.isMember("Max distance")) espConfig.maxDistance = espJson["Max distance"].asFloat();
     }
@@ -483,7 +483,7 @@ void Config::load(size_t id) noexcept
             if (snaplinesJson.isMember("Rainbow")) snaplinesConfig.rainbow = snaplinesJson["Rainbow"].asBool();
             if (snaplinesJson.isMember("Rainbow speed")) snaplinesConfig.rainbowSpeed = snaplinesJson["Rainbow speed"].asFloat();
         }
-        
+
         if (espJson.isMember("Box")) {
             const auto& boxJson = espJson["Box"];
             auto& boxConfig = espConfig.box;
@@ -820,6 +820,7 @@ void Config::load(size_t id) noexcept
         if (miscJson.isMember("Reveal ranks")) misc.revealRanks = miscJson["Reveal ranks"].asBool();
         if (miscJson.isMember("Reveal money")) misc.revealMoney = miscJson["Reveal money"].asBool();
         if (miscJson.isMember("Reveal suspect")) misc.revealSuspect = miscJson["Reveal suspect"].asBool();
+        if (miscJson.isMember("Team Damage Counter")) misc.teamDamageCounter = miscJson["Team Damage Counter"].asBool();
 
         if (const auto& spectatorList{ miscJson["Spectator list"] }; spectatorList.isObject()) {
             if (const auto& enabled{ spectatorList["Enabled"] }; enabled.isBool())
@@ -1301,7 +1302,7 @@ void Config::save(size_t id) const noexcept
         }
 
         espJson["Box type"] = espConfig.boxType;
-        
+
         {
             auto& outlineJson = espJson["Outline"];
             const auto& outlineConfig = espConfig.outline;
@@ -1550,7 +1551,7 @@ void Config::save(size_t id) const noexcept
 
     {
         auto& miscJson = json["Misc"];
-        
+
         miscJson["Menu key"] = misc.menuKey;
         miscJson["Anti AFK kick"] = misc.antiAfkKick;
         miscJson["Auto strafe"] = misc.autoStrafe;

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -27,7 +27,7 @@ public:
         bool rainbow{ false };
         float rainbowSpeed{ 0.6f };
     };
-    
+
     struct ColorToggle : public Color {
         bool enabled{ false };
     };
@@ -126,7 +126,7 @@ public:
             ColorToggle distance;
             float maxDistance{ 0.0f };
         };
-       
+
         struct Player : public Shared {
             ColorToggle eyeTraces;
             ColorToggle health;
@@ -244,6 +244,7 @@ public:
         bool revealRanks{ false };
         bool revealMoney{ false };
         bool revealSuspect{ false };
+        bool teamDamageCounter{ false };
         ColorToggle spectatorList;
         ColorToggle watermark;
         bool fixAnimationLOD{ false };

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -1064,6 +1064,7 @@ void GUI::renderMiscWindow(bool contentOnly) noexcept
     ImGui::SetNextItemWidth(120.0f);
     ImGui::SliderFloat("Max angle delta", &config.misc.maxAngleDelta, 0.0f, 255.0f, "%.2f");
     ImGui::Checkbox("Fake prime", &config.misc.fakePrime);
+    ImGui::Checkbox("Team Damage Counter", &config.misc.teamDamageCounter);
 
     if (ImGui::Button("Unhook"))
         hooks.restore();

--- a/Osiris/Hacks/Misc.h
+++ b/Osiris/Hacks/Misc.h
@@ -13,6 +13,9 @@
 
 namespace Misc
 {
+    inline int teamDamage = 0;
+    inline int teamKills = 0;
+
     void edgejump(UserCmd* cmd) noexcept;
     void slowwalk(UserCmd* cmd) noexcept;
     void inverseRagdollGravity() noexcept;
@@ -36,6 +39,7 @@ namespace Misc
     void fixTabletSignal() noexcept;
     void fakePrime() noexcept;
     void killMessage(GameEvent& event) noexcept;
+    void teamDamageCounter(GameEvent* event) noexcept;
 
     constexpr void fixMovement(UserCmd* cmd, float yaw) noexcept
     {

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -228,7 +228,7 @@ static void __stdcall paintTraverse(unsigned int panel, bool forceRepaint, bool 
         Esp::render();
         Misc::drawBombTimer();
         Misc::spectatorList();
-        Misc::watermark();        
+        Misc::watermark();
         Visuals::hitMarker();
     }
     hooks.panel.callOriginal<void, 41>(panel, forceRepaint, allowForce);
@@ -327,13 +327,19 @@ static bool __stdcall fireEventClientSide(GameEvent* event) noexcept
     if (event) {
         switch (fnv::hashRuntime(event->getName())) {
         case fnv::hash("player_death"):
+            Misc::teamDamageCounter(event);
             Misc::killMessage(*event);
             SkinChanger::overrideHudIcon(*event);
             break;
         case fnv::hash("player_hurt"):
+            Misc::teamDamageCounter(event);
             Misc::playHitSound(*event);
-            Visuals::hitEffect(event);                
+            Visuals::hitEffect(event);
             Visuals::hitMarker(event);
+            break;
+        case fnv::hash("round_announce_match_start"):
+            Misc::teamKills = 0;
+            Misc::teamDamage = 0;
             break;
         }
     }


### PR DESCRIPTION
When enabled in Misc, logs damage done to teammates in the developer console (`~`).
Example: `[ Friendly Fire] Kills: <2> Damage: <148>`

Keeps counting but doesn't log when the option is disabled (prevents desync)
Resets when the match starts, after warmup.

*also my vs plugins removed some trailing whitespace*

Built status with VC++ / VS2019
Debug x86: Success
Release x86: Success

Download with `git clone https://github.com/xAkiraMiura/Osiris.git -b team-damage-indicator`