### PR TITLE
Added Ammo Bar to Player ESP, resized bar width, moved health text above the healthbar

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -284,7 +284,21 @@ void Config::load(size_t id) noexcept
             if (armorBarJson.isMember("Rainbow")) armorBarConfig.rainbow = armorBarJson["Rainbow"].asBool();
             if (armorBarJson.isMember("Rainbow speed")) armorBarConfig.rainbowSpeed = armorBarJson["Rainbow speed"].asFloat();
         }
+        if (espJson.isMember("Ammo bar")) {
+            const auto& ammoBarJson = espJson["Ammo bar"];
+            auto& ammoBarConfig = espConfig.ammoBar;
 
+            if (ammoBarJson.isMember("Enabled")) ammoBarConfig.enabled = ammoBarJson["Enabled"].asBool();
+
+            if (ammoBarJson.isMember("Color")) {
+                ammoBarConfig.color[0] = ammoBarJson["Color"][0].asFloat();
+                ammoBarConfig.color[1] = ammoBarJson["Color"][1].asFloat();
+                ammoBarConfig.color[2] = ammoBarJson["Color"][2].asFloat();
+            }
+
+            if (ammoBarJson.isMember("Rainbow")) ammoBarConfig.rainbow = ammoBarJson["Rainbow"].asBool();
+            if (ammoBarJson.isMember("Rainbow speed")) ammoBarConfig.rainbowSpeed = ammoBarJson["Rainbow speed"].asFloat();
+        }
         if (espJson.isMember("Money")) {
             const auto& moneyJson = espJson["Money"];
             auto& moneyConfig = espConfig.money;
@@ -1129,6 +1143,17 @@ void Config::save(size_t id) const noexcept
             armorBarJson["Color"][2] = armorBarConfig.color[2];
             armorBarJson["Rainbow"] = armorBarConfig.rainbow;
             armorBarJson["Rainbow speed"] = armorBarConfig.rainbowSpeed;
+        }
+        {
+            auto& ammoJson = espJson["Ammo bar"];
+            const auto& ammoConfig = espConfig.ammoBar;
+
+            ammoJson["Enabled"] = ammoConfig.enabled;
+            ammoJson["Color"][0] = ammoConfig.color[0];
+            ammoJson["Color"][1] = ammoConfig.color[1];
+            ammoJson["Color"][2] = ammoConfig.color[2];
+            ammoJson["Rainbow"] = ammoConfig.rainbow;
+            ammoJson["Rainbow speed"] = ammoConfig.rainbowSpeed;
         }
 
         {

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -132,6 +132,7 @@ public:
             ColorToggle healthBar;
             ColorToggle armor;
             ColorToggle armorBar;
+            ColorToggle ammoBar;
             ColorToggle money;
             ColorToggle headDot;
             ColorToggle activeWeapon;

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -627,8 +627,9 @@ void GUI::renderEspWindow(bool contentOnly) noexcept
             ImGuiCustom::colorPicker("Head dot", config->esp.players[selected].headDot);
             ImGui::SameLine(spacing);
             ImGuiCustom::colorPicker("Health bar", config->esp.players[selected].healthBar);
-            ImGuiCustom::colorPicker("Name", config->esp.players[selected].name);
+            ImGuiCustom::colorPicker("Ammo Bar", config->esp.players[selected].ammoBar);
             ImGui::SameLine(spacing);
+            ImGuiCustom::colorPicker("Name", config->esp.players[selected].name);
             ImGuiCustom::colorPicker("Armor", config->esp.players[selected].armor);
             ImGuiCustom::colorPicker("Money", config->esp.players[selected].money);
             ImGui::SameLine(spacing);

--- a/Osiris/Hacks/Esp.cpp
+++ b/Osiris/Hacks/Esp.cpp
@@ -224,6 +224,8 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
 
         float drawPositionX = bbox.x0 - 5;
 
+        float drawPositionXXX = bbox.x0 + 60;
+
         if (config.healthBar.enabled) {
             static auto gameType{ interfaces->cvar->findVar("game_type") };
             static auto survivalMaxHealth{ interfaces->cvar->findVar("sv_dz_player_max_health") };
@@ -236,14 +238,25 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
                 interfaces->surface->setDrawColor(config.healthBar.color);
 
             interfaces->surface->drawFilledRect(drawPositionX - 1, bbox.y0 + abs(bbox.y1 - bbox.y0) * (maxHealth - entity->health()) / static_cast<float>(maxHealth), drawPositionX, bbox.y1);
-            
+            if (config.health.enabled) {
+                if (config.health.rainbow)
+                    interfaces->surface->setTextColor(rainbowColor(memory->globalVars->realtime, config.health.rainbowSpeed));
+                else
+                    interfaces->surface->setTextColor(config.health.color);
+                if (entity->health() < 100)
+                {
+                    interfaces->surface->setTextPosition(drawPositionX - 5, bbox.y0 + abs(bbox.y1 - bbox.y0) * (maxHealth - entity->health()) / static_cast<float>(maxHealth) - 15);
+                    interfaces->surface->setTextFont(config.font);
+                    interfaces->surface->printText(std::to_wstring(entity->health()));
+                }
+            }
             if (config.outline.enabled) {
                 if (config.outline.rainbow)
                     interfaces->surface->setDrawColor(rainbowColor(memory->globalVars->realtime, config.outline.rainbowSpeed));
                 else
                     interfaces->surface->setDrawColor(config.outline.color);
 
-                interfaces->surface->drawOutlinedRect(drawPositionX - 2, bbox.y0 - 1, drawPositionX + 1, bbox.y1 + 1);
+                interfaces->surface->drawOutlinedRect(drawPositionX - 2, bbox.y0 + abs(bbox.y1 - bbox.y0) * (maxHealth - entity->health()) / static_cast<float>(maxHealth), drawPositionX + 1, bbox.y1 + 1);
             }
             drawPositionX -= 7;
         }
@@ -262,7 +275,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
                 else
                     interfaces->surface->setDrawColor(config.outline.color);
 
-                interfaces->surface->drawOutlinedRect(drawPositionX - 2, bbox.y0 - 1, drawPositionX + 1, bbox.y1 + 1);
+                interfaces->surface->drawOutlinedRect(drawPositionX - 2, bbox.y0 + abs(bbox.y1 - bbox.y0) * (100.0f - entity->armor()) / 100.0f, drawPositionX + 1, bbox.y1 + 1);
             }
             drawPositionX -= 7;
         }
@@ -274,7 +287,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
                 else
                     interfaces->surface->setDrawColor(config.ammoBar.color);
 
-                interfaces->surface->drawFilledRect(drawPositionX - 1, bbox.y0 + abs(bbox.y1 - bbox.y0) * (iClip - iClipMax) / iClip, drawPositionX, bbox.y1);
+                interfaces->surface->drawFilledRect(drawPositionX - 2, bbox.y0 + abs(bbox.y1 - bbox.y0) * (iClip - iClipMax) / iClip, drawPositionX, bbox.y1);
 
                 if (config.outline.enabled) {
                     if (config.outline.rainbow)
@@ -282,7 +295,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
                     else
                         interfaces->surface->setDrawColor(config.outline.color);
 
-                    interfaces->surface->drawOutlinedRect(drawPositionX - 2, bbox.y0 - 1, drawPositionX + 1, bbox.y1 + 1);
+                    interfaces->surface->drawOutlinedRect(drawPositionX - 2, bbox.y0 + abs(bbox.y1 - bbox.y0) * (iClip - iClipMax) / iClip, drawPositionX + 1, bbox.y1 + 1);
                 }
             drawPositionX -= 7;
         }
@@ -317,15 +330,6 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
         }     
 
         float drawPositionY = bbox.y0;
-
-        if (config.health.enabled) {
-            if (config.health.rainbow)
-                interfaces->surface->setTextColor(rainbowColor(memory->globalVars->realtime, config.health.rainbowSpeed));
-            else
-                interfaces->surface->setTextColor(config.health.color);
-
-            renderPositionedText(config.font, (std::to_wstring(entity->health()) + L" HP").c_str(), { bbox.x1 + 5, drawPositionY });
-         }
 
         if (config.armor.enabled) {
             if (config.armor.rainbow)

--- a/Osiris/Hacks/Esp.cpp
+++ b/Osiris/Hacks/Esp.cpp
@@ -235,7 +235,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
             else
                 interfaces->surface->setDrawColor(config.healthBar.color);
 
-            interfaces->surface->drawFilledRect(drawPositionX - 3, bbox.y0 + abs(bbox.y1 - bbox.y0) * (maxHealth - entity->health()) / static_cast<float>(maxHealth), drawPositionX, bbox.y1);
+            interfaces->surface->drawFilledRect(drawPositionX - 1, bbox.y0 + abs(bbox.y1 - bbox.y0) * (maxHealth - entity->health()) / static_cast<float>(maxHealth), drawPositionX, bbox.y1);
             
             if (config.outline.enabled) {
                 if (config.outline.rainbow)
@@ -243,7 +243,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
                 else
                     interfaces->surface->setDrawColor(config.outline.color);
 
-                interfaces->surface->drawOutlinedRect(drawPositionX - 4, bbox.y0 - 1, drawPositionX + 1, bbox.y1 + 1);
+                interfaces->surface->drawOutlinedRect(drawPositionX - 2, bbox.y0 - 1, drawPositionX + 1, bbox.y1 + 1);
             }
             drawPositionX -= 7;
         }
@@ -254,7 +254,7 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
             else
                 interfaces->surface->setDrawColor(config.armorBar.color);
 
-            interfaces->surface->drawFilledRect(drawPositionX - 3, bbox.y0 + abs(bbox.y1 - bbox.y0) * (100.0f - entity->armor()) / 100.0f, drawPositionX, bbox.y1);
+            interfaces->surface->drawFilledRect(drawPositionX - 1, bbox.y0 + abs(bbox.y1 - bbox.y0) * (100.0f - entity->armor()) / 100.0f, drawPositionX, bbox.y1);
 
             if (config.outline.enabled) {
                 if (config.outline.rainbow)
@@ -262,8 +262,28 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
                 else
                     interfaces->surface->setDrawColor(config.outline.color);
 
-                interfaces->surface->drawOutlinedRect(drawPositionX - 4, bbox.y0 - 1, drawPositionX + 1, bbox.y1 + 1);
+                interfaces->surface->drawOutlinedRect(drawPositionX - 2, bbox.y0 - 1, drawPositionX + 1, bbox.y1 + 1);
             }
+            drawPositionX -= 7;
+        }
+            if (config.ammoBar.enabled) {
+                int iClip = entity->getActiveWeapon()->getWeaponData()->maxClip;
+                int iClipMax = entity->getActiveWeapon()->clip();
+                if (config.ammoBar.rainbow)
+                    interfaces->surface->setDrawColor(rainbowColor(memory->globalVars->realtime, config.ammoBar.rainbowSpeed));
+                else
+                    interfaces->surface->setDrawColor(config.ammoBar.color);
+
+                interfaces->surface->drawFilledRect(drawPositionX - 1, bbox.y0 + abs(bbox.y1 - bbox.y0) * (iClip - iClipMax) / iClip, drawPositionX, bbox.y1);
+
+                if (config.outline.enabled) {
+                    if (config.outline.rainbow)
+                        interfaces->surface->setDrawColor(rainbowColor(memory->globalVars->realtime, config.outline.rainbowSpeed));
+                    else
+                        interfaces->surface->setDrawColor(config.outline.color);
+
+                    interfaces->surface->drawOutlinedRect(drawPositionX - 2, bbox.y0 - 1, drawPositionX + 1, bbox.y1 + 1);
+                }
             drawPositionX -= 7;
         }
 

--- a/Osiris/Hacks/Esp.cpp
+++ b/Osiris/Hacks/Esp.cpp
@@ -224,8 +224,6 @@ static void renderPlayerBox(Entity* entity, const Config::Esp::Player& config) n
 
         float drawPositionX = bbox.x0 - 5;
 
-        float drawPositionXXX = bbox.x0 + 60;
-
         if (config.healthBar.enabled) {
             static auto gameType{ interfaces->cvar->findVar("game_type") };
             static auto survivalMaxHealth{ interfaces->cvar->findVar("sv_dz_player_max_health") };


### PR DESCRIPTION
Simple ammo bar esp, useful for pushing when they are low ammo. Also made the health, armor and ammo bar smaller, personal preference, you can enlarge them as you please.
_if anyone can make this horizontal i would be very grateful :)_

Video: 
https://streamable.com/385hhg

