### PR TITLE
 Add "On key" mode for glowing (related to #1527) 

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -94,6 +94,11 @@ void Config::load(size_t id) noexcept
         if (glowJson.isMember("Enabled")) glowConfig.enabled = glowJson["Enabled"].asBool();
         if (glowJson.isMember("healthBased")) glowConfig.healthBased = glowJson["healthBased"].asBool();
 
+        if (glowJson.isMember("On key")) glowConfig.onKey = glowJson["On key"].asBool();
+        if (glowJson.isMember("Toogle")) glowConfig.toggle = glowJson["Toogle"].asBool();
+        if (glowJson.isMember("Key")) glowConfig.key = glowJson["Key"].asInt();
+        if (glowJson.isMember("Key mode")) glowConfig.keyMode = glowJson["Key mode"].asInt();
+
         // TODO: remove soon
         if (glowJson.isMember("alpha")) glowConfig.color[3] = glowJson["alpha"].asFloat();
 
@@ -1013,6 +1018,10 @@ void Config::save(size_t id) const noexcept
         glowJson["Enabled"] = glowConfig.enabled;
         glowJson["healthBased"] = glowConfig.healthBased;
         glowJson["style"] = glowConfig.style;
+        glowJson["On key"] = glowConfig.onKey;
+        glowJson["Toggle"] = glowConfig.toggle;
+        glowJson["Key"] = glowConfig.key;
+        glowJson["Key mode"] = glowConfig.keyMode;
 
         {
             auto& colorJson = glowJson["Color"];

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -94,6 +94,10 @@ public:
         bool enabled{ false };
         bool healthBased{ false };
         int style{ 0 };
+        bool onKey = false;
+        int key = 0;
+        bool toggle{ true };
+        int keyMode{ 0 };
     };
     std::array<Glow, 21> glow;
 

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -441,6 +441,15 @@ void GUI::renderGlowWindow(bool contentOnly) noexcept
     ImGui::Separator();
     ImGui::Columns(2, nullptr, false);
     ImGui::SetColumnOffset(1, 150.0f);
+    ImGui::Checkbox("On key", &config->glow[currentItem].onKey);
+    ImGui::SameLine();
+    hotkey(config->glow[currentItem].key);
+    ImGui::SameLine();
+    ImGui::PushID(2);
+    ImGui::PushItemWidth(70.0f);
+    ImGui::Combo("", &config->glow[currentItem].keyMode, "Hold\0Toggle\0");
+    ImGui::PopItemWidth();
+    ImGui::PopID();
     ImGui::Checkbox("Health based", &config->glow[currentItem].healthBased);
 
     ImGuiCustom::colorPopup("Color", config->glow[currentItem].color, &config->glow[currentItem].rainbow, &config->glow[currentItem].rainbowSpeed);

--- a/Osiris/Hacks/Glow.cpp
+++ b/Osiris/Hacks/Glow.cpp
@@ -15,7 +15,7 @@ void Glow::render() noexcept
     if (!localPlayer)
         return;
 
-    const auto& glow = config->glow;
+    auto& glow = config->glow;
 
     Glow::clearCustomObjects();
 
@@ -53,6 +53,18 @@ void Glow::render() noexcept
 
         auto applyGlow = [&glowobject](decltype(glow[0])& glow, int health = 0) noexcept
         {
+            if (glow.onKey) {
+                if (!glow.keyMode) {
+                    if (!GetAsyncKeyState(glow.key))
+                        return;
+                }
+                else {
+                    if (GetAsyncKeyState(glow.key) & 1)
+                        glow.toggle = !glow.toggle;
+                    if (!glow.toggle)
+                        return;
+                }
+            }
             if (glow.enabled) {
                 glowobject.renderWhenOccluded = true;
                 glowobject.glowAlpha = glow.color[3];


### PR DESCRIPTION
It supports multiple types of glow (allies, enemies and etc.) without any contradiction. 
![demo](https://user-images.githubusercontent.com/12499740/86457646-a7399180-bd2c-11ea-85a1-498a167e004a.png)
