### PR TITLE
GUI Window Position SaveToConfig (lock/renember window position) //fixForNewConfig

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -532,6 +532,44 @@ static void from_json(const json& j, Config::Reportbot& r)
     read<value_t::boolean>(j, "Other Hacking", r.other);
 }
 
+static void from_json(const json& j, Config::Wpos& w)
+{
+    read<value_t::float>(j, "wpos Aimbot X", wpos.AimbotX);                         read<value_t::float>(j, "wpos Aimbot Y", wpos.AimbotY);
+    read<value_t::float>(j, "wpos AntiAim X", wpos.AntiAimX);                       read<value_t::float>(j, "wpos AntiAim Y", wpos.AntiAimY);
+    read<value_t::float>(j, "wpos TriggerBot X", wpos.TriggerBotX);                 read<value_t::float>(j, "wpos TriggerBot Y", wpos.TriggerBotY);
+    read<value_t::float>(j, "wpos Backtrack X", wpos.BacktrackX);                   read<value_t::float>(j, "wpos Backtrack Y", wpos.BacktrackY);
+    read<value_t::float>(j, "wpos Glow X", wpos.GlowX);                             read<value_t::float>(j, "wpos Glow Y", wpos.GlowY);
+    read<value_t::float>(j, "wpos Chams X", wpos.ChamsX);                           read<value_t::float>(j, "wpos Chams Y", wpos.ChamsY);
+    read<value_t::float>(j, "wpos ESP X", wpos.EspX);                               read<value_t::float>(j, "wpos ESP Y", wpos.EspY);
+    read<value_t::float>(j, "wpos Visuals X", wpos.VisualsX);                       read<value_t::float>(j, "wpos Visuals Y", wpos.VisualsY);
+    read<value_t::float>(j, "wpos Skinchanger X", wpos.SkinchangerX);               read<value_t::float>(j, "wpos Skinchanger Y", wpos.SkinchangerY);
+    read<value_t::float>(j, "wpos Sound X", wpos.SoundX);                           read<value_t::float>(j, "wpos Sound Y", wpos.SoundY);
+    read<value_t::float>(j, "wpos Style X", wpos.StyleX);                           read<value_t::float>(j, "wpos Style Y", wpos.StyleY);
+    read<value_t::float>(j, "wpos Misc X", wpos.MiscX);                             read<value_t::float>(j, "wpos Misc Y", wpos.MiscY);
+    read<value_t::float>(j, "wpos Reportbot X", wpos.ReportbotX);                   read<value_t::float>(j, "wpos Reportbot Y", wpos.ReportbotY);
+    read<value_t::float>(j, "wpos Config X", wpos.ConfigX);                         read<value_t::float>(j, "wpos Config Y", wpos.ConfigY);
+    read<value_t::float>(j, "wpos Style2 X", wpos.Style2X);                         read<value_t::float>(j, "wpos Style2 Y", wpos.Style2Y);
+    read<value_t::float>(j, "wpos PurchaseList X", wpos.PurchaseListX);             read<value_t::float>(j, "wpos PurchaseList Y", wpos.PurchaseListY);
+    read<value_t::float>(j, "wpos PurchaseList ScaleX", wpos.PurchaseListScaleX);   read<value_t::float>(j, "PurchaseList ScaleY", wpos.PurchaseListScaleY);
+    //
+    read<value_t::boolean>(j, "wpos Aimbot Lock", wpos.LockSelectedFlags[0]);
+    read<value_t::boolean>(j, "wpos Anti Aim Lock", wpos.LockSelectedFlags[1]);
+    read<value_t::boolean>(j, "wpos Triggerbot Lock", wpos.LockSelectedFlags[2]);
+    read<value_t::boolean>(j, "wpos Backtrack Lock", wpos.LockSelectedFlags[3]);
+    read<value_t::boolean>(j, "wpos Glow Lock", wpos.LockSelectedFlags[4]);
+    read<value_t::boolean>(j, "wpos Chams Lock", wpos.LockSelectedFlags[5]);
+    read<value_t::boolean>(j, "wpos Esp Lock", wpos.LockSelectedFlags[6]);
+    read<value_t::boolean>(j, "wpos Visuals Lock", wpos.LockSelectedFlags[7]);
+    read<value_t::boolean>(j, "wpos Skinchanger Lock", wpos.LockSelectedFlags[8]);
+    read<value_t::boolean>(j, "wpos Sound Lock", wpos.LockSelectedFlags[9]);
+    read<value_t::boolean>(j, "wpos Style Lock", wpos.LockSelectedFlags[10]);
+    read<value_t::boolean>(j, "wpos Misc Lock", wpos.LockSelectedFlags[11]);
+    read<value_t::boolean>(j, "wpos Reportbot Lock", wpos.LockSelectedFlags[12]);
+    read<value_t::boolean>(j, "wpos Config Lock", wpos.LockSelectedFlags[13]);
+    read<value_t::boolean>(j, "wpos Style2 Lock", wpos.LockSelectedFlags[14]);
+    read<value_t::boolean>(j, "wpos PurchaseList Lock", wpos.LockSelectedFlags[15]);
+}
+
 void Config::load(size_t id) noexcept
 {
     json j;
@@ -953,7 +991,7 @@ static void to_json(json& j, const Config::Visuals::ColorCorrection& o)
     WRITE("Saturation", saturation)
     WRITE("Ghost", ghost)
     WRITE("Green", green)
-    WRITE("Yellow", yellow)  
+    WRITE("Yellow", yellow)
 }
 
 static void to_json(json& j, const Config::Visuals& o)
@@ -1053,6 +1091,44 @@ static void to_json(json& j, const item_setting& o)
     if (o.custom_name[0])
         j["Custom name"] = o.custom_name;
     WRITE("Stickers", stickers)
+}
+
+static void to_json(json& j, const Config::Wpos& w)
+{
+    WRITE("wpos Aimbot X", AimbotX) WRITE("wpos Aimbot Y", AimbotY)
+    WRITE("wpos AntiAim X", AimbotX) WRITE("wpos AntiAim Y", AimbotY)
+    WRITE("wpos TriggerBot X", AimbotX) WRITE("wpos TriggerBot Y", AimbotY)
+    WRITE("wpos Backtrack X", AimbotX) WRITE("wpos Backtrack Y", AimbotY)
+    WRITE("wpos Glow X", AimbotX) WRITE("wpos Glow Y", AimbotY)
+    WRITE("wpos Chams X", AimbotX) WRITE("wpos Chams Y", AimbotY)
+    WRITE("wpos ESP X", AimbotX) WRITE("wpos ESP Y", AimbotY)
+    WRITE("wpos Visuals X", AimbotX) WRITE("wpos Visuals Y", AimbotY)
+    WRITE("wpos Skinchanger X", AimbotX) WRITE("wpos Skinchanger Y", AimbotY)
+    WRITE("wpos Sound X", AimbotX) WRITE("wpos Sound Y", AimbotY)
+    WRITE("wpos Style X", AimbotX) WRITE("wpos Style Y", AimbotY)
+    WRITE("wpos Misc X", AimbotX) WRITE("wpos Misc Y", AimbotY)
+    WRITE("wpos Reportbot X", AimbotX) WRITE("wpos Reportbot Y", AimbotY)
+    WRITE("wpos Config X", AimbotX) WRITE("wpos Config Y", AimbotY)
+    WRITE("wpos Style2 X", AimbotX) WRITE("wpos Style2 Y", AimbotY)
+    WRITE("wpos PurchaseList X", AimbotX) WRITE("wpos PurchaseList Y", AimbotY)
+    WRITE("wpos PurchaseList ScaleX", AimbotX) WRITE("wpos PurchaseList ScaleY", AimbotY)
+    //
+    WRITE("wpos Aimbot Lock", LockSelectedFlags[0])
+    WRITE("wpos Anti Aim Lock", LockSelectedFlags[1])
+    WRITE("wpos Triggerbot Lock", LockSelectedFlags[2])
+    WRITE("wpos Backtrack Lock", LockSelectedFlags[3])
+    WRITE("wpos Glow Lock", LockSelectedFlags[4])
+    WRITE("wpos Chams Lock", LockSelectedFlags[5])
+    WRITE("wpos Esp Lock", LockSelectedFlags[6])
+    WRITE("wpos Visuals Lock", LockSelectedFlags[7])
+    WRITE("wpos Skinchanger Lock", LockSelectedFlags[8])
+    WRITE("wpos Sound Lock", LockSelectedFlags[9])
+    WRITE("wpos Style Lock", LockSelectedFlags[10])
+    WRITE("wpos Misc Lock", LockSelectedFlags[11])
+    WRITE("wpos Reportbot Lock", LockSelectedFlags[12])
+    WRITE("wpos Config Lock", LockSelectedFlags[13])
+    WRITE("wpos Style2 Lock", LockSelectedFlags[14])
+    WRITE("wpos PurchaseList Lock", LockSelectedFlags[15])
 }
 
 void Config::save(size_t id) const noexcept

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -534,40 +534,40 @@ static void from_json(const json& j, Config::Reportbot& r)
 
 static void from_json(const json& j, Config::Wpos& w)
 {
-    read<value_t::float>(j, "wpos Aimbot X", wpos.AimbotX);                         read<value_t::float>(j, "wpos Aimbot Y", wpos.AimbotY);
-    read<value_t::float>(j, "wpos AntiAim X", wpos.AntiAimX);                       read<value_t::float>(j, "wpos AntiAim Y", wpos.AntiAimY);
-    read<value_t::float>(j, "wpos TriggerBot X", wpos.TriggerBotX);                 read<value_t::float>(j, "wpos TriggerBot Y", wpos.TriggerBotY);
-    read<value_t::float>(j, "wpos Backtrack X", wpos.BacktrackX);                   read<value_t::float>(j, "wpos Backtrack Y", wpos.BacktrackY);
-    read<value_t::float>(j, "wpos Glow X", wpos.GlowX);                             read<value_t::float>(j, "wpos Glow Y", wpos.GlowY);
-    read<value_t::float>(j, "wpos Chams X", wpos.ChamsX);                           read<value_t::float>(j, "wpos Chams Y", wpos.ChamsY);
-    read<value_t::float>(j, "wpos ESP X", wpos.EspX);                               read<value_t::float>(j, "wpos ESP Y", wpos.EspY);
-    read<value_t::float>(j, "wpos Visuals X", wpos.VisualsX);                       read<value_t::float>(j, "wpos Visuals Y", wpos.VisualsY);
-    read<value_t::float>(j, "wpos Skinchanger X", wpos.SkinchangerX);               read<value_t::float>(j, "wpos Skinchanger Y", wpos.SkinchangerY);
-    read<value_t::float>(j, "wpos Sound X", wpos.SoundX);                           read<value_t::float>(j, "wpos Sound Y", wpos.SoundY);
-    read<value_t::float>(j, "wpos Style X", wpos.StyleX);                           read<value_t::float>(j, "wpos Style Y", wpos.StyleY);
-    read<value_t::float>(j, "wpos Misc X", wpos.MiscX);                             read<value_t::float>(j, "wpos Misc Y", wpos.MiscY);
-    read<value_t::float>(j, "wpos Reportbot X", wpos.ReportbotX);                   read<value_t::float>(j, "wpos Reportbot Y", wpos.ReportbotY);
-    read<value_t::float>(j, "wpos Config X", wpos.ConfigX);                         read<value_t::float>(j, "wpos Config Y", wpos.ConfigY);
-    read<value_t::float>(j, "wpos Style2 X", wpos.Style2X);                         read<value_t::float>(j, "wpos Style2 Y", wpos.Style2Y);
-    read<value_t::float>(j, "wpos PurchaseList X", wpos.PurchaseListX);             read<value_t::float>(j, "wpos PurchaseList Y", wpos.PurchaseListY);
-    read<value_t::float>(j, "wpos PurchaseList ScaleX", wpos.PurchaseListScaleX);   read<value_t::float>(j, "PurchaseList ScaleY", wpos.PurchaseListScaleY);
+    read_number(j, "wpos Aimbot X", w.AimbotX);                         read_number(j, "wpos Aimbot Y", w.AimbotY);
+    read_number(j, "wpos AntiAim X", w.AntiAimX);                       read_number(j, "wpos AntiAim Y", w.AntiAimY);
+    read_number(j, "wpos TriggerBot X", w.TriggerBotX);                 read_number(j, "wpos TriggerBot Y", w.TriggerBotY);
+    read_number(j, "wpos Backtrack X", w.BacktrackX);                   read_number(j, "wpos Backtrack Y", w.BacktrackY);
+    read_number(j, "wpos Glow X", w.GlowX);                             read_number(j, "wpos Glow Y", w.GlowY);
+    read_number(j, "wpos Chams X", w.ChamsX);                           read_number(j, "wpos Chams Y", w.ChamsY);
+    read_number(j, "wpos ESP X", w.EspX);                               read_number(j, "wpos ESP Y", w.EspY);
+    read_number(j, "wpos Visuals X", w.VisualsX);                       read_number(j, "wpos Visuals Y", w.VisualsY);
+    read_number(j, "wpos Skinchanger X", w.SkinchangerX);               read_number(j, "wpos Skinchanger Y", w.SkinchangerY);
+    read_number(j, "wpos Sound X", w.SoundX);                           read_number(j, "wpos Sound Y", w.SoundY);
+    read_number(j, "wpos Style X", w.StyleX);                           read_number(j, "wpos Style Y", w.StyleY);
+    read_number(j, "wpos Misc X", w.MiscX);                             read_number(j, "wpos Misc Y", w.MiscY);
+    read_number(j, "wpos Reportbot X", w.ReportbotX);                   read_number(j, "wpos Reportbot Y", w.ReportbotY);
+    read_number(j, "wpos Config X", w.ConfigX);                         read_number(j, "wpos Config Y", w.ConfigY);
+    read_number(j, "wpos Style2 X", w.Style2X);                         read_number(j, "wpos Style2 Y", w.Style2Y);
+    read_number(j, "wpos PurchaseList X", w.PurchaseListX);             read_number(j, "wpos PurchaseList Y", w.PurchaseListY);
+    read_number(j, "wpos PurchaseList ScaleX", w.PurchaseListScaleX);   read_number(j, "PurchaseList ScaleY", w.PurchaseListScaleY);
     //
-    read<value_t::boolean>(j, "wpos Aimbot Lock", wpos.LockSelectedFlags[0]);
-    read<value_t::boolean>(j, "wpos Anti Aim Lock", wpos.LockSelectedFlags[1]);
-    read<value_t::boolean>(j, "wpos Triggerbot Lock", wpos.LockSelectedFlags[2]);
-    read<value_t::boolean>(j, "wpos Backtrack Lock", wpos.LockSelectedFlags[3]);
-    read<value_t::boolean>(j, "wpos Glow Lock", wpos.LockSelectedFlags[4]);
-    read<value_t::boolean>(j, "wpos Chams Lock", wpos.LockSelectedFlags[5]);
-    read<value_t::boolean>(j, "wpos Esp Lock", wpos.LockSelectedFlags[6]);
-    read<value_t::boolean>(j, "wpos Visuals Lock", wpos.LockSelectedFlags[7]);
-    read<value_t::boolean>(j, "wpos Skinchanger Lock", wpos.LockSelectedFlags[8]);
-    read<value_t::boolean>(j, "wpos Sound Lock", wpos.LockSelectedFlags[9]);
-    read<value_t::boolean>(j, "wpos Style Lock", wpos.LockSelectedFlags[10]);
-    read<value_t::boolean>(j, "wpos Misc Lock", wpos.LockSelectedFlags[11]);
-    read<value_t::boolean>(j, "wpos Reportbot Lock", wpos.LockSelectedFlags[12]);
-    read<value_t::boolean>(j, "wpos Config Lock", wpos.LockSelectedFlags[13]);
-    read<value_t::boolean>(j, "wpos Style2 Lock", wpos.LockSelectedFlags[14]);
-    read<value_t::boolean>(j, "wpos PurchaseList Lock", wpos.LockSelectedFlags[15]);
+    read<value_t::boolean>(j, "wpos Aimbot Lock", w.LockSelectedFlags[0]);
+    read<value_t::boolean>(j, "wpos Anti Aim Lock", w.LockSelectedFlags[1]);
+    read<value_t::boolean>(j, "wpos Triggerbot Lock", w.LockSelectedFlags[2]);
+    read<value_t::boolean>(j, "wpos Backtrack Lock", w.LockSelectedFlags[3]);
+    read<value_t::boolean>(j, "wpos Glow Lock", w.LockSelectedFlags[4]);
+    read<value_t::boolean>(j, "wpos Chams Lock", w.LockSelectedFlags[5]);
+    read<value_t::boolean>(j, "wpos Esp Lock", w.LockSelectedFlags[6]);
+    read<value_t::boolean>(j, "wpos Visuals Lock", w.LockSelectedFlags[7]);
+    read<value_t::boolean>(j, "wpos Skinchanger Lock", w.LockSelectedFlags[8]);
+    read<value_t::boolean>(j, "wpos Sound Lock", w.LockSelectedFlags[9]);
+    read<value_t::boolean>(j, "wpos Style Lock", w.LockSelectedFlags[10]);
+    read<value_t::boolean>(j, "wpos Misc Lock", w.LockSelectedFlags[11]);
+    read<value_t::boolean>(j, "wpos Reportbot Lock", w.LockSelectedFlags[12]);
+    read<value_t::boolean>(j, "wpos Config Lock", w.LockSelectedFlags[13]);
+    read<value_t::boolean>(j, "wpos Style2 Lock", w.LockSelectedFlags[14]);
+    read<value_t::boolean>(j, "wpos PurchaseList Lock", w.LockSelectedFlags[15]);
 }
 
 void Config::load(size_t id) noexcept
@@ -1093,25 +1093,27 @@ static void to_json(json& j, const item_setting& o)
     WRITE("Stickers", stickers)
 }
 
-static void to_json(json& j, const Config::Wpos& w)
+static void to_json(json& j, const Config::Wpos& o)
 {
+    const Config::Wpos dummy;
+
     WRITE("wpos Aimbot X", AimbotX) WRITE("wpos Aimbot Y", AimbotY)
-    WRITE("wpos AntiAim X", AimbotX) WRITE("wpos AntiAim Y", AimbotY)
-    WRITE("wpos TriggerBot X", AimbotX) WRITE("wpos TriggerBot Y", AimbotY)
-    WRITE("wpos Backtrack X", AimbotX) WRITE("wpos Backtrack Y", AimbotY)
-    WRITE("wpos Glow X", AimbotX) WRITE("wpos Glow Y", AimbotY)
-    WRITE("wpos Chams X", AimbotX) WRITE("wpos Chams Y", AimbotY)
-    WRITE("wpos ESP X", AimbotX) WRITE("wpos ESP Y", AimbotY)
-    WRITE("wpos Visuals X", AimbotX) WRITE("wpos Visuals Y", AimbotY)
-    WRITE("wpos Skinchanger X", AimbotX) WRITE("wpos Skinchanger Y", AimbotY)
-    WRITE("wpos Sound X", AimbotX) WRITE("wpos Sound Y", AimbotY)
-    WRITE("wpos Style X", AimbotX) WRITE("wpos Style Y", AimbotY)
-    WRITE("wpos Misc X", AimbotX) WRITE("wpos Misc Y", AimbotY)
-    WRITE("wpos Reportbot X", AimbotX) WRITE("wpos Reportbot Y", AimbotY)
-    WRITE("wpos Config X", AimbotX) WRITE("wpos Config Y", AimbotY)
-    WRITE("wpos Style2 X", AimbotX) WRITE("wpos Style2 Y", AimbotY)
-    WRITE("wpos PurchaseList X", AimbotX) WRITE("wpos PurchaseList Y", AimbotY)
-    WRITE("wpos PurchaseList ScaleX", AimbotX) WRITE("wpos PurchaseList ScaleY", AimbotY)
+    WRITE("wpos AntiAim X", AntiAimX) WRITE("wpos AntiAim Y", AntiAimY)
+    WRITE("wpos TriggerBot X", TriggerBotX) WRITE("wpos TriggerBot Y", TriggerBotY)
+    WRITE("wpos Backtrack X", BacktrackX) WRITE("wpos Backtrack Y", BacktrackY)
+    WRITE("wpos Glow X", GlowX) WRITE("wpos Glow Y", GlowY)
+    WRITE("wpos Chams X", ChamsX) WRITE("wpos Chams Y", ChamsY)
+    WRITE("wpos ESP X", EspX) WRITE("wpos ESP Y", EspY)
+    WRITE("wpos Visuals X", VisualsX) WRITE("wpos Visuals Y", VisualsY)
+    WRITE("wpos Skinchanger X", SkinchangerX) WRITE("wpos Skinchanger Y", SkinchangerY)
+    WRITE("wpos Sound X", SoundX) WRITE("wpos Sound Y", SoundY)
+    WRITE("wpos Style X", StyleX) WRITE("wpos Style Y", StyleY)
+    WRITE("wpos Misc X", MiscX) WRITE("wpos Misc Y", MiscY)
+    WRITE("wpos Reportbot X", ReportbotX) WRITE("wpos Reportbot Y", ReportbotY)
+    WRITE("wpos Config X", ConfigX) WRITE("wpos Config Y", ConfigY)
+    WRITE("wpos Style2 X", Style2X) WRITE("wpos Style2 Y", Style2Y)
+    WRITE("wpos PurchaseList X", PurchaseListX) WRITE("wpos PurchaseList Y", PurchaseListY)
+    WRITE("wpos PurchaseList ScaleX", PurchaseListScaleX) WRITE("wpos PurchaseList ScaleY", PurchaseListScaleY)
     //
     WRITE("wpos Aimbot Lock", LockSelectedFlags[0])
     WRITE("wpos Anti Aim Lock", LockSelectedFlags[1])

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -341,7 +341,7 @@ public:
         int rounds{ 1 };
     } reportbot;
 
-    struct {
+    struct Wpos {
         float AimbotX{ 250.0f }; // wpos config .h //
         float AimbotY{ 250.0f };
         float AntiAimX{ 250.0f };

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -147,7 +147,7 @@ public:
             ColorToggle distance;
             float maxDistance{ 0.0f };
         };
-       
+
         struct Player : public Shared {
             ColorToggle eyeTraces;
             ColorToggle health;
@@ -341,8 +341,59 @@ public:
         int rounds{ 1 };
     } reportbot;
 
+    struct {
+        float AimbotX{ 250.0f }; // wpos config .h //
+        float AimbotY{ 250.0f };
+        float AntiAimX{ 250.0f };
+        float AntiAimY{ 250.0f };
+        float TriggerBotX{ 250.0f };
+        float TriggerBotY{ 250.0f };
+        float BacktrackX{ 250.0f };
+        float BacktrackY{ 250.0f };
+        float GlowX{ 250.0f };
+        float GlowY{ 250.0f };
+        float ChamsX{ 250.0f };
+        float ChamsY{ 250.0f };
+        float EspX{ 250.0f };
+        float EspY{ 250.0f };
+        float VisualsX{ 250.0f };
+        float VisualsY{ 250.0f };
+        float SkinchangerX{ 250.0f };
+        float SkinchangerY{ 250.0f };
+        float SoundX{ 250.0f };
+        float SoundY{ 250.0f };
+        float StyleX{ 250.0f };
+        float StyleY{ 250.0f };
+        float MiscX{ 250.0f };
+        float MiscY{ 250.0f };
+        float ReportbotX{ 250.0f };
+        float ReportbotY{ 250.0f };
+        float ConfigX{ 250.0f };
+        float ConfigY{ 250.0f };
+        float Style2X{ 250.0f };
+        float Style2Y{ 250.0f };
+        float PurchaseListX{ 250.0f };
+        float PurchaseListY{ 250.0f };
+        float PurchaseListScaleX{ 200.0f };
+        float PurchaseListScaleY{ 200.0f };
+
+        const char* LockFlags[16] = { // "wpos Locks" //
+            "Aimbot", "Anti Aim", "Triggerbot", "Backtrack",
+            "Glow", "Chams", "Esp", "Visuals", "Skinchanger",
+            "Sound", "Style", "Misc", "Reportbot", "Config",
+            "Style2", "PurchaseList"
+        };
+        bool LockSelectedFlags[16] = {
+            false, false, false, false,
+            false, false, false, false,
+            false, false, false, false,
+            false, false, false, false
+        };
+    } wpos;
+
     void scheduleFontLoad(const std::string& name) noexcept;
     bool loadScheduledFonts() noexcept;
+
 private:
     std::vector<std::string> scheduledFonts{ "Default" };
     std::filesystem::path path;

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -20,8 +20,8 @@
 #include "Interfaces.h"
 #include "SDK/InputSystem.h"
 
-constexpr auto windowFlags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize
-| ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
+constexpr auto windowFlags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
+constexpr auto wposwindowFlags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize;
 
 GUI::GUI() noexcept
 {
@@ -125,8 +125,24 @@ void GUI::renderAimbotWindow(bool contentOnly) noexcept
         if (!window.aimbot)
             return;
         ImGui::SetNextWindowSize({ 600.0f, 0.0f });
-        ImGui::Begin("Aimbot", &window.aimbot, windowFlags);
+        if (config->wpos.LockSelectedFlags[0] && config->style.menuStyle == 0) {
+            ImGui::Begin("Aimbot", &window.aimbot, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Aimbot", &window.aimbot, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[0]) {
+            if (config->wpos.AimbotX != ImGui::GetWindowPos().x) { config->wpos.AimbotX = ImGui::GetWindowPos().x; }
+            if (config->wpos.AimbotY != ImGui::GetWindowPos().y) { config->wpos.AimbotY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.AimbotX || ImGui::GetWindowPos().y != config->wpos.AimbotY) {
+                ImGui::SetWindowPos({ config->wpos.AimbotX, config->wpos.AimbotY });
+            }
+        }
+    }
+
     static int currentCategory{ 0 };
     ImGui::PushItemWidth(110.0f);
     ImGui::PushID(0);
@@ -260,8 +276,24 @@ void GUI::renderAntiAimWindow(bool contentOnly) noexcept
         if (!window.antiAim)
             return;
         ImGui::SetNextWindowSize({ 0.0f, 0.0f });
-        ImGui::Begin("Anti aim", &window.antiAim, windowFlags);
+        if (config->wpos.LockSelectedFlags[1] && config->style.menuStyle == 0) {
+            ImGui::Begin("Anti aim", &window.antiAim, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Anti aim", &window.antiAim, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[1]) {
+            if (config->wpos.AntiAimX != ImGui::GetWindowPos().x) { config->wpos.AntiAimX = ImGui::GetWindowPos().x; }
+            if (config->wpos.AntiAimY != ImGui::GetWindowPos().y) { config->wpos.AntiAimY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.AntiAimX || ImGui::GetWindowPos().y != config->wpos.AntiAimY) {
+                ImGui::SetWindowPos({ config->wpos.AntiAimX, config->wpos.AntiAimY });
+            }
+        }
+    }
+
     ImGui::Checkbox("Enabled", &config->antiAim.enabled);
     ImGui::Checkbox("##pitch", &config->antiAim.pitch);
     ImGui::SameLine();
@@ -277,8 +309,24 @@ void GUI::renderTriggerbotWindow(bool contentOnly) noexcept
         if (!window.triggerbot)
             return;
         ImGui::SetNextWindowSize({ 0.0f, 0.0f });
-        ImGui::Begin("Triggerbot", &window.triggerbot, windowFlags);
+        if (config->wpos.LockSelectedFlags[2] && config->style.menuStyle == 0) {
+            ImGui::Begin("Triggerbot", &window.triggerbot, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Triggerbot", &window.triggerbot, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[2]) {
+            if (config->wpos.TriggerBotX != ImGui::GetWindowPos().x) { config->wpos.TriggerBotX = ImGui::GetWindowPos().x; }
+            if (config->wpos.TriggerBotY != ImGui::GetWindowPos().y) { config->wpos.TriggerBotY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.TriggerBotX || ImGui::GetWindowPos().y != config->wpos.TriggerBotY) {
+                ImGui::SetWindowPos({ config->wpos.TriggerBotX, config->wpos.TriggerBotY });
+            }
+        }
+    }
+
     static int currentCategory{ 0 };
     ImGui::PushItemWidth(110.0f);
     ImGui::PushID(0);
@@ -400,8 +448,24 @@ void GUI::renderBacktrackWindow(bool contentOnly) noexcept
         if (!window.backtrack)
             return;
         ImGui::SetNextWindowSize({ 0.0f, 0.0f });
-        ImGui::Begin("Backtrack", &window.backtrack, windowFlags);
+        if (config->wpos.LockSelectedFlags[3] && config->style.menuStyle == 0) {
+            ImGui::Begin("Backtrack", &window.backtrack, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Backtrack", &window.backtrack, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[3]) {
+            if (config->wpos.BacktrackX != ImGui::GetWindowPos().x) { config->wpos.BacktrackX = ImGui::GetWindowPos().x; }
+            if (config->wpos.BacktrackY != ImGui::GetWindowPos().y) { config->wpos.BacktrackY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.BacktrackX || ImGui::GetWindowPos().y != config->wpos.BacktrackY) {
+                ImGui::SetWindowPos({ config->wpos.BacktrackX, config->wpos.BacktrackY });
+            }
+        }
+    }
+
     ImGui::Checkbox("Enabled", &config->backtrack.enabled);
     ImGui::Checkbox("Ignore smoke", &config->backtrack.ignoreSmoke);
     ImGui::Checkbox("Recoil based fov", &config->backtrack.recoilBasedFov);
@@ -418,8 +482,24 @@ void GUI::renderGlowWindow(bool contentOnly) noexcept
         if (!window.glow)
             return;
         ImGui::SetNextWindowSize({ 450.0f, 0.0f });
-        ImGui::Begin("Glow", &window.glow, windowFlags);
+        if (config->wpos.LockSelectedFlags[4] && config->style.menuStyle == 0) {
+            ImGui::Begin("Glow", &window.glow, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Glow", &window.glow, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[4]) {
+            if (config->wpos.GlowX != ImGui::GetWindowPos().x) { config->wpos.GlowX = ImGui::GetWindowPos().x; }
+            if (config->wpos.GlowY != ImGui::GetWindowPos().y) { config->wpos.GlowY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.GlowX || ImGui::GetWindowPos().y != config->wpos.GlowY) {
+                ImGui::SetWindowPos({ config->wpos.GlowX, config->wpos.GlowY });
+            }
+        }
+    }
+
     static int currentCategory{ 0 };
     ImGui::PushItemWidth(110.0f);
     ImGui::PushID(0);
@@ -449,7 +529,7 @@ void GUI::renderGlowWindow(bool contentOnly) noexcept
     ImGui::NextColumn();
     ImGui::SetNextItemWidth(100.0f);
     ImGui::Combo("Style", &config->glow[currentItem].style, "Default\0Rim3d\0Edge\0Edge Pulse\0");
-   
+
     ImGui::Columns(1);
     if (!contentOnly)
         ImGui::End();
@@ -461,8 +541,24 @@ void GUI::renderChamsWindow(bool contentOnly) noexcept
         if (!window.chams)
             return;
         ImGui::SetNextWindowSize({ 0.0f, 0.0f });
-        ImGui::Begin("Chams", &window.chams, windowFlags);
+        if (config->wpos.LockSelectedFlags[5] && config->style.menuStyle == 0) {
+            ImGui::Begin("Chams", &window.chams, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Chams", &window.chams, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[5]) {
+            if (config->wpos.ChamsX != ImGui::GetWindowPos().x) { config->wpos.ChamsX = ImGui::GetWindowPos().x; }
+            if (config->wpos.ChamsY != ImGui::GetWindowPos().y) { config->wpos.ChamsY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.ChamsX || ImGui::GetWindowPos().y != config->wpos.ChamsY) {
+                ImGui::SetWindowPos({ config->wpos.ChamsX, config->wpos.ChamsY });
+            }
+        }
+    }
+
     static int currentCategory{ 0 };
     ImGui::PushItemWidth(110.0f);
     ImGui::PushID(0);
@@ -518,7 +614,22 @@ void GUI::renderStreamProofESPWindow(bool contentOnly) noexcept
         if (!window.streamProofESP)
             return;
         ImGui::SetNextWindowSize({ 0.0f, 0.0f });
-        ImGui::Begin("Stream Proof ESP", &window.streamProofESP, windowFlags);
+        if (config->wpos.LockSelectedFlags[6] && config->style.menuStyle == 0) {
+            ImGui::Begin("Stream Proof ESP", &window.streamProofESP, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Stream Proof ESP", &window.streamProofESP, windowFlags);
+        }
+    }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[6]) {
+            if (config->wpos.EspX != ImGui::GetWindowPos().x) { config->wpos.EspX = ImGui::GetWindowPos().x; }
+            if (config->wpos.EspY != ImGui::GetWindowPos().y) { config->wpos.EspY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.EspX || ImGui::GetWindowPos().y != config->wpos.EspY) {
+                ImGui::SetWindowPos({ config->wpos.EspX, config->wpos.EspY });
+            }
+        }
     }
 
     static std::size_t currentCategory;
@@ -876,8 +987,24 @@ void GUI::renderVisualsWindow(bool contentOnly) noexcept
         if (!window.visuals)
             return;
         ImGui::SetNextWindowSize({ 680.0f, 0.0f });
-        ImGui::Begin("Visuals", &window.visuals, windowFlags);
+        if (config->wpos.LockSelectedFlags[7] && config->style.menuStyle == 0) {
+            ImGui::Begin("Visuals", &window.visuals, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Visuals", &window.visuals, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[7]) {
+            if (config->wpos.VisualsX != ImGui::GetWindowPos().x) { config->wpos.VisualsX = ImGui::GetWindowPos().x; }
+            if (config->wpos.VisualsY != ImGui::GetWindowPos().y) { config->wpos.VisualsY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.VisualsX || ImGui::GetWindowPos().y != config->wpos.VisualsY) {
+                ImGui::SetWindowPos({ config->wpos.VisualsX, config->wpos.VisualsY });
+            }
+        }
+    }
+
     ImGui::Columns(2, nullptr, false);
     ImGui::SetColumnOffset(1, 280.0f);
     constexpr auto playerModels = "Default\0Special Agent Ava | FBI\0Operator | FBI SWAT\0Markus Delrow | FBI HRT\0Michael Syfers | FBI Sniper\0B Squadron Officer | SAS\0Seal Team 6 Soldier | NSWC SEAL\0Buckshot | NSWC SEAL\0Lt. Commander Ricksaw | NSWC SEAL\0Third Commando Company | KSK\0'Two Times' McCoy | USAF TACP\0Dragomir | Sabre\0Rezan The Ready | Sabre\0'The Doctor' Romanov | Sabre\0Maximus | Sabre\0Blackwolf | Sabre\0The Elite Mr. Muhlik | Elite Crew\0Ground Rebel | Elite Crew\0Osiris | Elite Crew\0Prof. Shahmat | Elite Crew\0Enforcer | Phoenix\0Slingshot | Phoenix\0Soldier | Phoenix\0Pirate\0Pirate Variant A\0Pirate Variant B\0Pirate Variant C\0Pirate Variant D\0Anarchist\0Anarchist Variant A\0Anarchist Variant B\0Anarchist Variant C\0Anarchist Variant D\0Balkan Variant A\0Balkan Variant B\0Balkan Variant C\0Balkan Variant D\0Balkan Variant E\0Jumpsuit Variant A\0Jumpsuit Variant B\0Jumpsuit Variant C\0";
@@ -963,7 +1090,22 @@ void GUI::renderSkinChangerWindow(bool contentOnly) noexcept
         if (!window.skinChanger)
             return;
         ImGui::SetNextWindowSize({ 700.0f, 0.0f });
-        ImGui::Begin("nSkinz", &window.skinChanger, windowFlags);
+        if (config->wpos.LockSelectedFlags[8] && config->style.menuStyle == 0) {
+            ImGui::Begin("nSkinz", &window.skinChanger, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("nSkinz", &window.skinChanger, windowFlags);
+        }
+    }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[8]) {
+            if (config->wpos.SkinchangerX != ImGui::GetWindowPos().x) { config->wpos.SkinchangerX = ImGui::GetWindowPos().x; }
+            if (config->wpos.SkinchangerY != ImGui::GetWindowPos().y) { config->wpos.SkinchangerY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.SkinchangerX || ImGui::GetWindowPos().y != config->wpos.SkinchangerY) {
+                ImGui::SetWindowPos({ config->wpos.SkinchangerX, config->wpos.SkinchangerY });
+            }
+        }
     }
 
     static auto itemIndex = 0;
@@ -1077,8 +1219,25 @@ void GUI::renderSoundWindow(bool contentOnly) noexcept
         if (!window.sound)
             return;
         ImGui::SetNextWindowSize({ 0.0f, 0.0f });
-        ImGui::Begin("Sound", &window.sound, windowFlags);
+        if (config->wpos.LockSelectedFlags[9] && config->style.menuStyle == 0) {
+            ImGui::Begin("Sound", &window.sound, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Sound", &window.sound, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[9]) {
+            if (config->wpos.SoundX != ImGui::GetWindowPos().x) { config->wpos.SoundX = ImGui::GetWindowPos().x; }
+            if (config->wpos.SoundY != ImGui::GetWindowPos().y) { config->wpos.SoundY = ImGui::GetWindowPos().y; }
+        }
+        else {
+            if (ImGui::GetWindowPos().x != config->wpos.SoundX || ImGui::GetWindowPos().y != config->wpos.SoundY) {
+                ImGui::SetWindowPos({ config->wpos.SoundX, config->wpos.SoundY });
+            }
+        }
+    }
+
     ImGui::SliderInt("Chicken volume", &config->sound.chickenVolume, 0, 200, "%d%%");
 
     static int currentCategory{ 0 };
@@ -1100,7 +1259,23 @@ void GUI::renderStyleWindow(bool contentOnly) noexcept
         if (!window.style)
             return;
         ImGui::SetNextWindowSize({ 0.0f, 0.0f });
-        ImGui::Begin("Style", &window.style, windowFlags);
+        if (config->wpos.LockSelectedFlags[10] && config->style.menuStyle == 0) {
+            ImGui::Begin("Style", &window.style, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Style", &window.style, windowFlags);
+        }
+    }
+
+    if (config->style.menuStyle == 0){
+        if (!config->wpos.LockSelectedFlags[10])
+        {
+            if (config->wpos.StyleX != ImGui::GetWindowPos().x) { config->wpos.StyleX = ImGui::GetWindowPos().x; }
+            if (config->wpos.StyleY != ImGui::GetWindowPos().y) { config->wpos.StyleY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.StyleX || ImGui::GetWindowPos().y != config->wpos.StyleY) {
+            ImGui::SetWindowPos({ config->wpos.StyleX, config->wpos.StyleY });
+            }
+        }
     }
 
     ImGui::PushItemWidth(150.0f);
@@ -1129,8 +1304,24 @@ void GUI::renderMiscWindow(bool contentOnly) noexcept
         if (!window.misc)
             return;
         ImGui::SetNextWindowSize({ 580.0f, 0.0f });
-        ImGui::Begin("Misc", &window.misc, windowFlags);
+        if (config->wpos.LockSelectedFlags[11] && config->style.menuStyle == 0) {
+            ImGui::Begin("Misc", &window.misc, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Misc", &window.misc, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[11]) {
+            if (config->wpos.MiscX != ImGui::GetWindowPos().x) { config->wpos.MiscX = ImGui::GetWindowPos().x; }
+            if (config->wpos.MiscY != ImGui::GetWindowPos().y) { config->wpos.MiscY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.MiscX || ImGui::GetWindowPos().y != config->wpos.MiscY) {
+                ImGui::SetWindowPos({ config->wpos.MiscX, config->wpos.MiscY });
+            }
+        }
+    }
+
     ImGui::Columns(2, nullptr, false);
     ImGui::SetColumnOffset(1, 230.0f);
     ImGui::TextUnformatted("Menu key");
@@ -1240,9 +1431,14 @@ void GUI::renderMiscWindow(bool contentOnly) noexcept
         ImGui::Checkbox("Only During Freeze Time", &config->misc.purchaseList.onlyDuringFreezeTime);
         ImGui::Checkbox("Show Prices", &config->misc.purchaseList.showPrices);
         ImGui::Checkbox("No Title Bar", &config->misc.purchaseList.noTitleBar);
+        ImGui::Checkbox("Lock/Save Scale/Position", &config->wpos.LockSelectedFlags[15]);
         ImGui::EndPopup();
     }
     ImGui::PopID();
+
+    if (config->style.menuStyle != 1){
+    ImGuiCustom::MultiCombo("Save and lock window position", config->wpos.LockFlags, config->wpos.LockSelectedFlags, 14);
+    } else { ImGui::Checkbox("Save and lock window position", &config->wpos.LockSelectedFlags[14]); }
 
     if (ImGui::Button("Unhook"))
         hooks->uninstall();
@@ -1258,8 +1454,24 @@ void GUI::renderReportbotWindow(bool contentOnly) noexcept
         if (!window.reportbot)
             return;
         ImGui::SetNextWindowSize({ 0.0f, 0.0f });
-        ImGui::Begin("Reportbot", &window.reportbot, windowFlags);
+        if (config->wpos.LockSelectedFlags[12] && config->style.menuStyle == 0) {
+            ImGui::Begin("Reportbot", &window.reportbot, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Reportbot", &window.reportbot, windowFlags);
+        }
     }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[12]) {
+            if (config->wpos.ReportbotX != ImGui::GetWindowPos().x) { config->wpos.ReportbotX = ImGui::GetWindowPos().x; }
+            if (config->wpos.ReportbotY != ImGui::GetWindowPos().y) { config->wpos.ReportbotY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.ReportbotX || ImGui::GetWindowPos().y != config->wpos.ReportbotY) {
+                ImGui::SetWindowPos({ config->wpos.ReportbotX, config->wpos.ReportbotY });
+            }
+        }
+    }
+
     ImGui::Checkbox("Enabled", &config->reportbot.enabled);
     ImGui::SameLine(0.0f, 50.0f);
     if (ImGui::Button("Reset"))
@@ -1288,7 +1500,22 @@ void GUI::renderConfigWindow(bool contentOnly) noexcept
         if (!window.config)
             return;
         ImGui::SetNextWindowSize({ 290.0f, 200.0f });
-        ImGui::Begin("Config", &window.config, windowFlags);
+        if (config->wpos.LockSelectedFlags[13] && config->style.menuStyle == 0) {
+            ImGui::Begin("Config", &window.config, windowFlags | wposwindowFlags);
+        } else {
+            ImGui::Begin("Config", &window.config, windowFlags);
+        }
+    }
+
+    if (config->style.menuStyle == 0) {
+        if (!config->wpos.LockSelectedFlags[13]) {
+            if (config->wpos.ConfigX != ImGui::GetWindowPos().x) { config->wpos.ConfigX = ImGui::GetWindowPos().x; }
+            if (config->wpos.ConfigY != ImGui::GetWindowPos().y) { config->wpos.ConfigY = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.ConfigX || ImGui::GetWindowPos().y != config->wpos.ConfigY) {
+                ImGui::SetWindowPos({ config->wpos.ConfigX, config->wpos.ConfigY });
+            }
+        }
     }
 
     ImGui::Columns(2, nullptr, false);
@@ -1380,7 +1607,20 @@ void GUI::renderConfigWindow(bool contentOnly) noexcept
 void GUI::renderGuiStyle2() noexcept
 {
     ImGui::SetNextWindowSize({ 600.0f, 0.0f });
-    ImGui::Begin("Osiris", nullptr, windowFlags | ImGuiWindowFlags_NoTitleBar);
+    if (config->wpos.LockSelectedFlags[14] && config->style.menuStyle == 0) {
+        ImGui::Begin("Osiris", nullptr, windowFlags | ImGuiWindowFlags_NoTitleBar | wposwindowFlags);
+    } else {
+        ImGui::Begin("Osiris", nullptr, windowFlags | ImGuiWindowFlags_NoTitleBar);
+    }
+
+        if (!config->wpos.LockSelectedFlags[14]) {
+            if (config->wpos.Style2X != ImGui::GetWindowPos().x) { config->wpos.Style2X = ImGui::GetWindowPos().x; }
+            if (config->wpos.Style2Y != ImGui::GetWindowPos().y) { config->wpos.Style2Y = ImGui::GetWindowPos().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.Style2X || ImGui::GetWindowPos().y != config->wpos.Style2Y) {
+                ImGui::SetWindowPos({ config->wpos.Style2X, config->wpos.Style2Y });
+            }
+        }
 
     if (ImGui::BeginTabBar("TabBar", ImGuiTabBarFlags_Reorderable | ImGuiTabBarFlags_FittingPolicyScroll | ImGuiTabBarFlags_NoTooltip)) {
         if (ImGui::BeginTabItem("Aimbot")) {

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -723,17 +723,39 @@ void Misc::purchaseList(GameEvent* event) noexcept
         if ((!interfaces->engine->isInGame() || freezeEnd != 0.0f && memory->globalVars->realtime > freezeEnd + (!config->misc.purchaseList.onlyDuringFreezeTime ? mp_buytime->getFloat() : 0.0f) || purchaseDetails.empty() || purchaseTotal.empty()) && !gui->open)
             return;
 
-        ImGui::SetNextWindowSize({ 200.0f, 200.0f }, ImGuiCond_Once);
-
         ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoCollapse;
         if (!gui->open)
             windowFlags |= ImGuiWindowFlags_NoInputs;
         if (config->misc.purchaseList.noTitleBar)
             windowFlags |= ImGuiWindowFlags_NoTitleBar;
-        
+        if (config->wpos.LockSelectedFlags[15]) {
+            windowFlags |= ImGuiWindowFlags_NoMove;
+            windowFlags |= ImGuiWindowFlags_NoResize;
+        }
+
+        const auto [width, height] = interfaces->surface->getScreenSize();
+        float textPositionY = static_cast<float>(0.5f * height);
+
+        ImGui::SetNextWindowSize({ 200.0f, 200.0f }, ImGuiCond_Once);
+        ImGui::SetNextWindowPos({ 0.0f, textPositionY }, ImGuiCond_Once);
+
         ImGui::PushStyleVar(ImGuiStyleVar_WindowTitleAlign, { 0.5f, 0.5f });
         ImGui::Begin("Purchases", nullptr, windowFlags);
         ImGui::PopStyleVar();
+
+        if (!config->wpos.LockSelectedFlags[15]) {
+            if (config->wpos.PurchaseListX != ImGui::GetWindowPos().x) { config->wpos.PurchaseListX = ImGui::GetWindowPos().x; }
+            if (config->wpos.PurchaseListY != ImGui::GetWindowPos().y) { config->wpos.PurchaseListY = ImGui::GetWindowPos().y; }
+            if (config->wpos.PurchaseListScaleX != ImGui::GetWindowSize().x) { config->wpos.PurchaseListScaleX = ImGui::GetWindowSize().x; }
+            if (config->wpos.PurchaseListScaleY != ImGui::GetWindowSize().y) { config->wpos.PurchaseListScaleY = ImGui::GetWindowSize().y; }
+        } else {
+            if (ImGui::GetWindowPos().x != config->wpos.PurchaseListX || ImGui::GetWindowPos().y != config->wpos.PurchaseListY) {
+                ImGui::SetWindowPos({ config->wpos.PurchaseListX, config->wpos.PurchaseListY });
+            }
+            if (ImGui::GetWindowSize().x != config->wpos.PurchaseListScaleX || ImGui::GetWindowSize().y != config->wpos.PurchaseListScaleY) {
+                ImGui::SetWindowSize({ config->wpos.PurchaseListScaleX, config->wpos.PurchaseListScaleY });
+            }
+        }
 
         if (config->misc.purchaseList.mode == PurchaseList::Details) {
             for (const auto& [playerName, purchases] : purchaseDetails) {

--- a/Osiris/imguiCustom.cpp
+++ b/Osiris/imguiCustom.cpp
@@ -130,3 +130,65 @@ void ImGuiCustom::arrowButtonDisabled(const char* id, ImGuiDir dir) noexcept
     ImGui::ArrowButtonEx(id, dir, { sz, sz }, ImGuiButtonFlags_Disabled);
     ImGui::PopStyleVar();
 }
+
+bool ImGuiCustom::MultiCombo(const char* label, const char** displayName, bool* data, int dataSize) {
+
+    ImGui::PushID(label);
+
+    char previewText[1024] = { 0 };
+    char buf[1024] = { 0 };
+    char buf2[1024] = { 0 };
+    int currentPreviewTextLen = 0;
+    float multicomboWidth = 115.f;
+
+    for (int i = 0; i < dataSize; i++) {
+
+        if (data[i] == true) {
+
+            if (currentPreviewTextLen == 0)
+                sprintf(buf, "%s", displayName[i]);
+            else
+                sprintf(buf, ", %s", displayName[i]);
+
+            strcpy(buf2, previewText);
+            sprintf(buf2 + currentPreviewTextLen, buf);
+            ImVec2 textSize = ImGui::CalcTextSize(buf2);
+
+            if (textSize.x > multicomboWidth) {
+
+                sprintf(previewText + currentPreviewTextLen, "...");
+                currentPreviewTextLen += (int)strlen("...");
+                break;
+            }
+
+            sprintf(previewText + currentPreviewTextLen, buf);
+            currentPreviewTextLen += (int)strlen(buf);
+        }
+    }
+
+    if (currentPreviewTextLen > 0)
+        previewText[currentPreviewTextLen] = NULL;
+    else
+        sprintf(previewText, " -");
+
+    bool isDataChanged = false;
+
+    if (ImGui::BeginCombo(label, previewText)) {
+
+        for (int i = 0; i < dataSize; i++) {
+
+            sprintf(buf, displayName[i]);
+
+            if (ImGui::Selectable(buf, data[i], ImGuiSelectableFlags_DontClosePopups)) {
+
+                data[i] = !data[i];
+                isDataChanged = true;
+            }
+        }
+
+        ImGui::EndCombo();
+    }
+
+    ImGui::PopID();
+    return isDataChanged;
+}

--- a/Osiris/imguiCustom.h
+++ b/Osiris/imguiCustom.h
@@ -20,4 +20,5 @@ namespace ImGuiCustom
     void colorPicker(const char* name, ColorToggleThickness& colorConfig) noexcept;
     void colorPicker(const char* name, ColorToggleThicknessRounding& colorConfig) noexcept;
     void arrowButtonDisabled(const char* id, ImGuiDir dir) noexcept;
+    bool MultiCombo(const char* label, const char** displayName, bool* data, int dataSize);
 }


### PR DESCRIPTION
As title says.

known bugs:
none at the moment

Its awesome to have window position just the way you like it without setup each gaming session.

Thoughts?

Found in GUI misc. tab bottom right.

The goal of this in my opinion would be a "lock" button/or icon next to the "X" that closes the window, to do what i have here but cleaner and on each window not in one place, but this works great nontheless currently.

(i reopened this in a new pull because i messed up the last one with pulls, this is cleaner than #1795)