### PR TITLE
Added mat_disable_bloom...

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -369,6 +369,7 @@ static void from_json(const json& j, Config::Visuals& v)
     read<value_t::boolean>(j, "No weapons", v.noWeapons);
     read<value_t::boolean>(j, "No smoke", v.noSmoke);
     read<value_t::boolean>(j, "No blur", v.noBlur);
+    read<value_t::boolean>(j, "No bloom", v.noBloom);
     read<value_t::boolean>(j, "No scope overlay", v.noScopeOverlay);
     read<value_t::boolean>(j, "No grass", v.noGrass);
     read<value_t::boolean>(j, "No shadows", v.noShadows);
@@ -928,6 +929,7 @@ static void to_json(json& j, const Config::Visuals& o)
     WRITE("No weapons", noWeapons);
     WRITE("No smoke", noSmoke);
     WRITE("No blur", noBlur);
+    WRITE("No bloom", noBloom);
     WRITE("No scope overlay", noScopeOverlay);
     WRITE("No grass", noGrass);
     WRITE("No shadows", noShadows);

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -142,6 +142,7 @@ public:
         bool noWeapons{ false };
         bool noSmoke{ false };
         bool noBlur{ false };
+        bool noBloom{ false };
         bool noScopeOverlay{ false };
         bool noGrass{ false };
         bool noShadows{ false };

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -919,7 +919,7 @@ void GUI::renderVisualsWindow(bool contentOnly) noexcept
     ImGui::Checkbox("No sleeves", &config->visuals.noSleeves);
     ImGui::Checkbox("No weapons", &config->visuals.noWeapons);
     ImGui::Checkbox("No smoke", &config->visuals.noSmoke);
-    ImGui::Checkbox("No blur", &config->visuals.noBlur);//mat_disable_bloom
+    ImGui::Checkbox("No blur", &config->visuals.noBlur);
     ImGui::Checkbox("No bloom", &config->visuals.noBloom);
     ImGui::Checkbox("No scope overlay", &config->visuals.noScopeOverlay);
     ImGui::Checkbox("No grass", &config->visuals.noGrass);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -919,7 +919,8 @@ void GUI::renderVisualsWindow(bool contentOnly) noexcept
     ImGui::Checkbox("No sleeves", &config->visuals.noSleeves);
     ImGui::Checkbox("No weapons", &config->visuals.noWeapons);
     ImGui::Checkbox("No smoke", &config->visuals.noSmoke);
-    ImGui::Checkbox("No blur", &config->visuals.noBlur);
+    ImGui::Checkbox("No blur", &config->visuals.noBlur);//mat_disable_bloom
+    ImGui::Checkbox("No bloom", &config->visuals.noBloom);
     ImGui::Checkbox("No scope overlay", &config->visuals.noScopeOverlay);
     ImGui::Checkbox("No grass", &config->visuals.noGrass);
     ImGui::Checkbox("No shadows", &config->visuals.noShadows);

--- a/Osiris/Hacks/Visuals.cpp
+++ b/Osiris/Hacks/Visuals.cpp
@@ -195,6 +195,15 @@ void Visuals::removeBlur(FrameStage stage) noexcept
     blur->setMaterialVarFlag(MaterialVarFlag::NO_DRAW, stage == FrameStage::RENDER_START && config->visuals.noBlur);
 }
 
+void Visuals::removeBloom() noexcept
+{
+    if (!localPlayer)
+        return;
+
+    static ConVar* bloomCvar = interfaces->cvar->findVar("mat_disable_bloom");
+    bloomCvar->setValue(config->visuals.noBloom ? 1 : 0);
+}
+
 void Visuals::updateBrightness() noexcept
 {
     static auto brightness = interfaces->cvar->findVar("mat_force_tonemap_scale");

--- a/Osiris/Hacks/Visuals.cpp
+++ b/Osiris/Hacks/Visuals.cpp
@@ -197,11 +197,8 @@ void Visuals::removeBlur(FrameStage stage) noexcept
 
 void Visuals::removeBloom() noexcept
 {
-    if (!localPlayer)
-        return;
-
     static ConVar* bloomCvar = interfaces->cvar->findVar("mat_disable_bloom");
-    bloomCvar->setValue(config->visuals.noBloom ? 1 : 0);
+    bloomCvar->setValue(config->visuals.noBloom);
 }
 
 void Visuals::updateBrightness() noexcept

--- a/Osiris/Hacks/Visuals.h
+++ b/Osiris/Hacks/Visuals.h
@@ -11,6 +11,7 @@ namespace Visuals
     void thirdperson() noexcept;
     void removeVisualRecoil(FrameStage stage) noexcept;
     void removeBlur(FrameStage stage) noexcept;
+    void removeBloom() noexcept;
     void updateBrightness() noexcept;
     void removeGrass(FrameStage stage) noexcept;
     void remove3dSky() noexcept;

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -194,6 +194,7 @@ static int __stdcall doPostScreenEffects(int param) noexcept
     if (interfaces->engine->isInGame()) {
         Visuals::thirdperson();
         Misc::inverseRagdollGravity();
+        Visuals::removeBloom();
         Visuals::reduceFlashEffect();
         Visuals::updateBrightness();
         Visuals::remove3dSky();


### PR DESCRIPTION
...toggle switch to visuals window below disable blur

Requested at #2007

Well i do belive that disable post-proccesing removes the bloom as well, but in anycase its standalone now, i do not notice a fps gain myself but maybe this helps someone.