### PR TITLE
Custom skybox

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -417,7 +417,7 @@ static void from_json(const json& j, Config::Visuals& v)
     read(j, "Flash reduction", v.flashReduction);
     read(j, "Brightness", v.brightness);
     read(j, "Skybox", v.skybox);
-    read<value_t::object>(j, "Custom skybox", m.customSkybox);
+    read<value_t::object>(j, "Custom skybox", v.customSkybox);
     read<value_t::object>(j, "World", v.world);
     read<value_t::object>(j, "Sky", v.sky);
     read(j, "Deagle spinner", v.deagleSpinner);

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -417,6 +417,7 @@ static void from_json(const json& j, Config::Visuals& v)
     read(j, "Flash reduction", v.flashReduction);
     read(j, "Brightness", v.brightness);
     read(j, "Skybox", v.skybox);
+    read<value_t::object>(j, "Custom skybox", m.customSkybox);
     read<value_t::object>(j, "World", v.world);
     read<value_t::object>(j, "Sky", v.sky);
     read(j, "Deagle spinner", v.deagleSpinner);
@@ -998,6 +999,7 @@ static void to_json(json& j, const Config::Visuals& o)
     WRITE("Flash reduction", flashReduction);
     WRITE("Brightness", brightness);
     WRITE("Skybox", skybox);
+    WRITE("Custom skybox", customSkybox);
     WRITE("World", world);
     WRITE("Sky", sky);
     WRITE("Deagle spinner", deagleSpinner);

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -154,6 +154,7 @@ public:
         int flashReduction{ 0 };
         float brightness{ 0.0f };
         int skybox{ 0 };
+        std::string customSkybox;
         ColorToggle world;
         ColorToggle sky;
         bool deagleSpinner{ false };

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -954,6 +954,11 @@ void GUI::renderVisualsWindow(bool contentOnly) noexcept
     ImGui::PopID();
     ImGui::PopItemWidth();
     ImGui::Combo("Skybox", &config->visuals.skybox, Helpers::skyboxList.data(), Helpers::skyboxList.size());
+    if (config->visuals.skybox == 25) {
+        ImGui::InputText("Skybox filename", &config->visuals.customSkybox);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("skybox files must be put in csgo/materials/skybox/ directory");
+    }
     ImGuiCustom::colorPicker("World color", config->visuals.world);
     ImGuiCustom::colorPicker("Sky color", config->visuals.sky);
     ImGui::Checkbox("Deagle spinner", &config->visuals.deagleSpinner);

--- a/Osiris/Hacks/Visuals.cpp
+++ b/Osiris/Hacks/Visuals.cpp
@@ -399,8 +399,10 @@ void Visuals::skybox(FrameStage stage) noexcept
     if (stage != FrameStage::RENDER_START && stage != FrameStage::RENDER_END)
         return;
 
-    if (const auto& skyboxes = Helpers::skyboxList; stage == FrameStage::RENDER_START && config->visuals.skybox > 0 && static_cast<std::size_t>(config->visuals.skybox) < skyboxes.size()) {
+    if (const auto& skyboxes = Helpers::skyboxList; stage == FrameStage::RENDER_START && config->visuals.skybox > 0 && static_cast<std::size_t>(config->visuals.skybox) < skyboxes.size() - 1) {
         memory->loadSky(skyboxes[config->visuals.skybox]);
+    } else if (config->visuals.skybox == 25 && stage == FrameStage::RENDER_START) {
+        memory->loadSky(config->visuals.customSkybox.c_str());
     } else {
         static const auto sv_skyname = interfaces->cvar->findVar("sv_skyname");
         memory->loadSky(sv_skyname->string);

--- a/Osiris/Helpers.h
+++ b/Osiris/Helpers.h
@@ -34,5 +34,5 @@ namespace Helpers
         return start;
     }
 
-    inline constexpr std::array skyboxList{ "Default", "cs_baggage_skybox_", "cs_tibet", "embassy", "italy", "jungle", "nukeblank", "office", "sky_cs15_daylight01_hdr", "sky_cs15_daylight02_hdr", "sky_cs15_daylight03_hdr", "sky_cs15_daylight04_hdr", "sky_csgo_cloudy01", "sky_csgo_night_flat", "sky_csgo_night02", "sky_day02_05_hdr", "sky_day02_05", "sky_dust", "sky_l4d_rural02_ldr", "sky_venice", "vertigo_hdr", "vertigo", "vertigoblue_hdr", "vietnam", "sky_lunacy" };
+    inline constexpr std::array skyboxList{ "Default", "cs_baggage_skybox_", "cs_tibet", "embassy", "italy", "jungle", "nukeblank", "office", "sky_cs15_daylight01_hdr", "sky_cs15_daylight02_hdr", "sky_cs15_daylight03_hdr", "sky_cs15_daylight04_hdr", "sky_csgo_cloudy01", "sky_csgo_night_flat", "sky_csgo_night02", "sky_day02_05_hdr", "sky_day02_05", "sky_dust", "sky_l4d_rural02_ldr", "sky_venice", "vertigo_hdr", "vertigo", "vertigoblue_hdr", "vietnam", "sky_lunacy", "Custom" };
 }


### PR DESCRIPTION
_Edit: I just realised that this doesn't work in online servers, kinda sad tbh_

Add support of custom skyboxes.

Usage:
Drop your skybox files into csgo/materials/skybox/ directory (skybox consists of 12 files)
Select the "Custom" option from Skybox in Visuals tab
Type your custom skybox's name
And now you should have a custom skybox.

Example:

![20201010174622_1](https://user-images.githubusercontent.com/58109276/95659463-8fd72500-0b21-11eb-8bc2-f8a904a013f4.jpg)

Skybox used in this example: sky_descent (https://gamebanana.com/textures/4895)

