### PR TITLE
Remove includes suggested by CLion - 'Detect not directly used'

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -2,7 +2,6 @@
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
-#include <iterator>
 #include <system_error>
 
 #ifdef _WIN32

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -1,11 +1,8 @@
-﻿#include <algorithm>
-#include <array>
+﻿#include <array>
 #include <cwchar>
 #include <fstream>
-#include <iterator>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 #ifdef _WIN32

--- a/Osiris/Hacks/Aimbot.cpp
+++ b/Osiris/Hacks/Aimbot.cpp
@@ -1,24 +1,16 @@
 #include <algorithm>
-#include <array>
-#include <initializer_list>
-#include <memory>
 
 #include "Aimbot.h"
 #include "../Config.h"
-#include "../InputUtil.h"
 #include "../Interfaces.h"
 #include "../Memory.h"
 #include "../SDK/Engine.h"
 #include "../SDK/EngineTrace.h"
 #include "../SDK/Entity.h"
 #include "../SDK/EntityList.h"
-#include "../SDK/LocalPlayer.h"
 #include "../SDK/UserCmd.h"
-#include "../SDK/Vector.h"
-#include "../SDK/WeaponId.h"
 #include "../SDK/GlobalVars.h"
 #include "../SDK/PhysicsSurfaceProps.h"
-#include "../SDK/WeaponData.h"
 
 Vector Aimbot::calculateRelativeAngle(const Vector& source, const Vector& destination, const Vector& viewAngles) noexcept
 {

--- a/Osiris/Hacks/AntiAim.cpp
+++ b/Osiris/Hacks/AntiAim.cpp
@@ -2,11 +2,8 @@
 
 #include "../imgui/imgui.h"
 
-#include "../ConfigStructs.h"
 #include "../SDK/Entity.h"
-#include "../SDK/LocalPlayer.h"
 #include "../SDK/UserCmd.h"
-#include "../SDK/Vector.h"
 
 #if OSIRIS_ANTIAIM()
 

--- a/Osiris/Hacks/Backtrack.cpp
+++ b/Osiris/Hacks/Backtrack.cpp
@@ -9,7 +9,6 @@
 #include "../SDK/EntityList.h"
 #include "../SDK/FrameStage.h"
 #include "../SDK/GlobalVars.h"
-#include "../SDK/LocalPlayer.h"
 #include "../SDK/NetworkChannel.h"
 #include "../SDK/UserCmd.h"
 

--- a/Osiris/Hacks/Chams.cpp
+++ b/Osiris/Hacks/Chams.cpp
@@ -1,32 +1,24 @@
-#include <algorithm>
 #include <cstring>
 #include <deque>
-#include <memory>
-#include <string>
 #include <string_view>
 #include <tuple>
-#include <unordered_map>
 
 #include "Chams.h"
-#include "../Config.h"
 #include "../Helpers.h"
 #include "../Hooks.h"
 #include "../Interfaces.h"
 #include "../Memory.h"
 #include "Backtrack.h"
-#include "../InputUtil.h"
 #include "../SDK/ClassId.h"
 #include "../SDK/ClientClass.h"
 #include "../SDK/Entity.h"
 #include "../SDK/EntityList.h"
 #include "../SDK/GlobalVars.h"
-#include "../SDK/LocalPlayer.h"
 #include "../SDK/Material.h"
 #include "../SDK/MaterialSystem.h"
 #include "../SDK/ModelRender.h"
 #include "../SDK/StudioRender.h"
 #include "../SDK/KeyValues.h"
-#include "../SDK/Utils.h"
 
 static Material* normal;
 static Material* flat;

--- a/Osiris/Hacks/EnginePrediction.cpp
+++ b/Osiris/Hacks/EnginePrediction.cpp
@@ -1,12 +1,9 @@
-#include <memory>
-
 #include "../Interfaces.h"
 #include "../Memory.h"
 
 #include "../SDK/Entity.h"
 #include "../SDK/GameMovement.h"
 #include "../SDK/GlobalVars.h"
-#include "../SDK/LocalPlayer.h"
 #include "../SDK/MoveHelper.h"
 #include "../SDK/Prediction.h"
 

--- a/Osiris/Hacks/Glow.cpp
+++ b/Osiris/Hacks/Glow.cpp
@@ -1,6 +1,4 @@
-#include <algorithm>
 #include <array>
-#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -10,7 +8,6 @@
 #include "../imgui/imgui.h"
 
 #include "../ConfigStructs.h"
-#include "../InputUtil.h"
 #include "Glow.h"
 #include "../Helpers.h"
 #include "../Interfaces.h"
@@ -21,10 +18,6 @@
 #include "../SDK/Entity.h"
 #include "../SDK/EntityList.h"
 #include "../SDK/GlowObjectManager.h"
-#include "../SDK/LocalPlayer.h"
-#include "../SDK/Utils.h"
-#include "../SDK/UtlVector.h"
-#include "../SDK/Vector.h"
 #include "../imguiCustom.h"
 
 #if OSIRIS_GLOW()

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -11,7 +11,6 @@
 #include "../imgui/imgui_internal.h"
 
 #include "../Config.h"
-#include "../InputUtil.h"
 #include "../Interfaces.h"
 #include "../Memory.h"
 
@@ -33,19 +32,12 @@
 #include "../SDK/GlobalVars.h"
 #include "../SDK/ItemSchema.h"
 #include "../SDK/Localize.h"
-#include "../SDK/LocalPlayer.h"
 #include "../SDK/NetworkChannel.h"
 #include "../SDK/Panorama.h"
-#include "../SDK/Platform.h"
 #include "../SDK/UserCmd.h"
-#include "../SDK/UtlVector.h"
-#include "../SDK/Vector.h"
-#include "../SDK/WeaponData.h"
-#include "../SDK/WeaponId.h"
 #include "../SDK/WeaponSystem.h"
 
 #include "../GUI.h"
-#include "../Helpers.h"
 #include "../GameData.h"
 
 #include "../imguiCustom.h"

--- a/Osiris/Hacks/SkinChanger.cpp
+++ b/Osiris/Hacks/SkinChanger.cpp
@@ -17,7 +17,6 @@
 #include "SkinChanger.h"
 #include "../Config.h"
 #include "../Texture.h"
-#include "../fnv.h"
 
 #include "../SDK/ClassId.h"
 #include "../SDK/Client.h"
@@ -32,12 +31,7 @@
 #include "../SDK/GameEvent.h"
 #include "../SDK/ItemSchema.h"
 #include "../SDK/Localize.h"
-#include "../SDK/LocalPlayer.h"
 #include "../SDK/ModelInfo.h"
-#include "../SDK/Platform.h"
-#include "../SDK/WeaponId.h"
-
-#include "../Helpers.h"
 
 /* This file is part of nSkinz by namazso, licensed under the MIT license:
 *

--- a/Osiris/Hacks/Sound.cpp
+++ b/Osiris/Hacks/Sound.cpp
@@ -1,6 +1,5 @@
 #include <array>
 #include <functional>
-#include <memory>
 #include <string_view>
 
 #include "../imgui/imgui.h"
@@ -8,7 +7,6 @@
 #include "../Interfaces.h"
 #include "../SDK/Entity.h"
 #include "../SDK/EntityList.h"
-#include "../SDK/LocalPlayer.h"
 
 #include "Sound.h"
 

--- a/Osiris/Hacks/StreamProofESP.cpp
+++ b/Osiris/Hacks/StreamProofESP.cpp
@@ -1,6 +1,5 @@
 #include <algorithm>
 #include <array>
-#include <forward_list>
 #include <limits>
 #include <numbers>
 #include <unordered_map>
@@ -15,8 +14,6 @@
 
 #include "../Config.h"
 #include "../GameData.h"
-#include "../Helpers.h"
-#include "../InputUtil.h"
 #include "../SDK/Engine.h"
 #include "../SDK/GlobalVars.h"
 #include "../Memory.h"

--- a/Osiris/Hacks/Triggerbot.cpp
+++ b/Osiris/Hacks/Triggerbot.cpp
@@ -4,8 +4,6 @@
 #include "../SDK/Entity.h"
 #include "../SDK/GlobalVars.h"
 #include "../SDK/UserCmd.h"
-#include "../SDK/WeaponData.h"
-#include "../SDK/WeaponId.h"
 #include "Triggerbot.h"
 
 static bool keyPressed;

--- a/Osiris/Hacks/Visuals.cpp
+++ b/Osiris/Hacks/Visuals.cpp
@@ -10,7 +10,6 @@
 
 #include "../fnv.h"
 #include "../GameData.h"
-#include "../Helpers.h"
 #include "Visuals.h"
 
 #include "../SDK/ConVar.h"

--- a/Osiris/Helpers.cpp
+++ b/Osiris/Helpers.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-#include <array>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -1,5 +1,4 @@
 #include <functional>
-#include <string>
 
 #include "imgui/imgui.h"
 
@@ -50,13 +49,11 @@
 #include "SDK/Entity.h"
 #include "SDK/EntityList.h"
 #include "SDK/FrameStage.h"
-#include "SDK/GameEvent.h"
 #include "SDK/GameUI.h"
 #include "SDK/GlobalVars.h"
 #include "SDK/InputSystem.h"
 #include "SDK/MaterialSystem.h"
 #include "SDK/ModelRender.h"
-#include "SDK/Panel.h"
 #include "SDK/Platform.h"
 #include "SDK/RenderContext.h"
 #include "SDK/SoundInfo.h"

--- a/Osiris/SDK/Entity.cpp
+++ b/Osiris/SDK/Entity.cpp
@@ -1,7 +1,5 @@
 #include "Entity.h"
 
-#include "../Memory.h"
-#include "../Interfaces.h"
 #include "GlobalVars.h"
 #include "Localize.h"
 #include "ModelInfo.h"


### PR DESCRIPTION
Detect not directly used (default): this strategy follows the Include What You Use principle (the principle that if you use a symbol or type from a header, you should include that header) and detects the #includes directives with the declarations not used in the current file directly.

https://www.jetbrains.com/help/clion/unused-include-directive.html