### PR TITLE
Cross-platform calculateVmtLength() function

### DIFF
--- a/Osiris/Helpers.cpp
+++ b/Osiris/Helpers.cpp
@@ -7,6 +7,13 @@
 #include <fstream>
 #include <string_view>
 
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <dlfcn.h>
+#include <sys/mman.h>
+#endif
+
 #include "imgui/imgui.h"
 
 #include "ConfigStructs.h"
@@ -158,4 +165,19 @@ std::vector<char> Helpers::loadBinaryFile(const std::string& path) noexcept
     in.seekg(0, std::ios_base::beg);
     in.read(result.data(), result.size());
     return result;
+}
+
+std::size_t Helpers::calculateVmtLength(std::uintptr_t* vmt) noexcept
+{
+    std::size_t length = 0;
+#ifdef _WIN32
+    MEMORY_BASIC_INFORMATION memoryInfo;
+    while (VirtualQuery(LPCVOID(vmt[length]), &memoryInfo, sizeof(memoryInfo)) && memoryInfo.Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
+        length++;
+#else
+    Dl_info memoryInfo;
+    while (dladdr((void*)vmt[length], &memoryInfo) && mprotect((void*)memoryInfo.dli_fbase, 1, PROT_READ | PROT_WRITE | PROT_EXEC) == 0)
+        length++;
+#endif
+    return length;
 }

--- a/Osiris/Helpers.cpp
+++ b/Osiris/Helpers.cpp
@@ -9,9 +9,6 @@
 
 #ifdef _WIN32
 #include <Windows.h>
-#else
-#include <dlfcn.h>
-#include <sys/mman.h>
 #endif
 
 #include "imgui/imgui.h"
@@ -175,8 +172,7 @@ std::size_t Helpers::calculateVmtLength(std::uintptr_t* vmt) noexcept
     while (VirtualQuery(LPCVOID(vmt[length]), &memoryInfo, sizeof(memoryInfo)) && memoryInfo.Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
         length++;
 #else
-    Dl_info memoryInfo;
-    while (dladdr((void*)vmt[length], &memoryInfo) && mprotect((void*)memoryInfo.dli_fbase, 1, PROT_READ | PROT_WRITE | PROT_EXEC) == 0)
+    while(vmt[length])
         length++;
 #endif
     return length;

--- a/Osiris/Helpers.h
+++ b/Osiris/Helpers.h
@@ -51,4 +51,6 @@ namespace Helpers
 
     constexpr auto deg2rad(float degrees) noexcept { return degrees * (std::numbers::pi_v<float> / 180.0f); }
     constexpr auto rad2deg(float radians) noexcept { return radians * (180.0f / std::numbers::pi_v<float>); }
+
+    std::size_t calculateVmtLength(std::uintptr_t* vmt) noexcept;
 }

--- a/Osiris/Hooks/MinHook.cpp
+++ b/Osiris/Hooks/MinHook.cpp
@@ -1,19 +1,11 @@
 #include "MinHook.h"
 #include "../MinHook/MinHook.h"
-
-static auto calculateVmtLength(uintptr_t* vmt) noexcept
-{
-    std::size_t length = 0;
-    MEMORY_BASIC_INFORMATION memoryInfo;
-    while (VirtualQuery(LPCVOID(vmt[length]), &memoryInfo, sizeof(memoryInfo)) && memoryInfo.Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
-        length++;
-    return length;
-}
+#include "../Helpers.h"
 
 void MinHook::init(void* base) noexcept
 {
     this->base = base;
-    originals = std::make_unique<uintptr_t[]>(calculateVmtLength(*reinterpret_cast<uintptr_t**>(base)));
+    originals = std::make_unique<uintptr_t[]>(Helpers::calculateVmtLength(*reinterpret_cast<uintptr_t**>(base)));
 }
 
 void MinHook::hookAt(std::size_t index, void* fun) noexcept

--- a/Osiris/Hooks/VmtHook.cpp
+++ b/Osiris/Hooks/VmtHook.cpp
@@ -1,27 +1,13 @@
 #include <algorithm>
 
-#ifdef _WIN32
-#include <Windows.h>
-#endif
-
 #include "VmtHook.h"
-
-static auto calculateVmtLength(std::uintptr_t* vmt) noexcept
-{
-    std::size_t length = 0;
-#ifdef _WIN32
-    MEMORY_BASIC_INFORMATION memoryInfo;
-    while (VirtualQuery(LPCVOID(vmt[length]), &memoryInfo, sizeof(memoryInfo)) && memoryInfo.Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
-        length++;
-#endif
-    return length;
-}
+#include "../Helpers.h"
 
 void VmtHook::init(void* base) noexcept
 {
     this->base = base;
     auto vmt = *reinterpret_cast<std::uintptr_t**>(base);
-    length = calculateVmtLength(vmt);
+    length = Helpers::calculateVmtLength(vmt);
     oldVmt = std::make_unique<std::uintptr_t[]>(length);
     std::copy(vmt, vmt + length, oldVmt.get());
 }

--- a/Osiris/Hooks/VmtHook.cpp
+++ b/Osiris/Hooks/VmtHook.cpp
@@ -1,5 +1,9 @@
 #include <algorithm>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 #include "VmtHook.h"
 #include "../Helpers.h"
 

--- a/Osiris/Hooks/VmtSwap.cpp
+++ b/Osiris/Hooks/VmtSwap.cpp
@@ -1,29 +1,13 @@
 #include <algorithm>
 
-#ifdef _WIN32
-#include <Windows.h>
-#endif
-
 #include "VmtSwap.h"
-
-static auto calculateVmtLength(std::uintptr_t* vmt) noexcept
-{
-    std::size_t length = 0;
-#ifdef _WIN32
-    MEMORY_BASIC_INFORMATION memoryInfo;
-    while (VirtualQuery(LPCVOID(vmt[length]), &memoryInfo, sizeof(memoryInfo)) && memoryInfo.Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
-        length++;
-#else
-    length = 4096; // hardcoded for now
-#endif
-    return length;
-}
+#include "../Helpers.h"
 
 void VmtSwap::init(void* base) noexcept
 {
     this->base = base;
     oldVmt = *reinterpret_cast<std::uintptr_t**>(base);
-    std::size_t length = calculateVmtLength(oldVmt) + dynamicCastInfoLength;
+    std::size_t length = Helpers::calculateVmtLength(oldVmt) + dynamicCastInfoLength;
     newVmt = std::make_unique<std::uintptr_t[]>(length);
     std::copy(oldVmt - dynamicCastInfoLength, oldVmt - dynamicCastInfoLength + length, newVmt.get());
     *reinterpret_cast<std::uintptr_t**>(base) = newVmt.get() + dynamicCastInfoLength;


### PR DESCRIPTION
1. Moved calculateVmtLength() function to Helpers.cpp for code reuse
2. Implemented proper calculation for Linux
3. Changed MinHook, VmtHook and VmtSwap to call this function instead of duplicated code in three places.