### PR TITLE
Fix possible dx9 memory leaks

### DIFF
--- a/Osiris/imgui/imgui_impl_dx9.cpp
+++ b/Osiris/imgui/imgui_impl_dx9.cpp
@@ -134,14 +134,24 @@ void ImGui_ImplDX9_RenderDrawData(ImDrawData* draw_data)
         return;
 
     if (d3d9_state_block->Capture() != D3D_OK)
+    {
+        d3d9_state_block->Release();
         return;
+    }
 
     CUSTOMVERTEX* vtx_dst;
-    ImDrawIdx* idx_dst;
     if (g_pVB->Lock(0, (UINT)(draw_data->TotalVtxCount * sizeof(CUSTOMVERTEX)), (void**)&vtx_dst, D3DLOCK_DISCARD) < 0)
+    {
+        d3d9_state_block->Release();
         return;
+    }
+
+    ImDrawIdx* idx_dst;
     if (g_pIB->Lock(0, (UINT)(draw_data->TotalIdxCount * sizeof(ImDrawIdx)), (void**)&idx_dst, D3DLOCK_DISCARD) < 0)
+    {
+        d3d9_state_block->Release();
         return;
+    }
 
     for (int n = 0; n < draw_data->CmdListsCount; ++n) {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];


### PR DESCRIPTION
After `Capture()`, `Release()` must be called. See [Remarks](https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3dstateblock9-capture#remarks).

[Once again, since the stateblock object is an interface, you will need to release it when you are done with it.](https://docs.microsoft.com/en-us/windows/win32/direct3d9/state-blocks-save-and-restore-state#capture-individual-states)

See also, [the original imgui_impl_dx9.cpp#L150](https://github.com/ocornut/imgui/blob/master/backends/imgui_impl_dx9.cpp#L150).