### PR TITLE
[Bugfix] Fix reading of ColorToggle3 objects from config

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -86,12 +86,6 @@ Config::Config() noexcept
     std::sort(std::next(systemFonts.begin()), systemFonts.end());
 }
 
-static void from_json(const json& j, ColorToggle3& ct)
-{
-    from_json(j, static_cast<Color3&>(ct));
-    read(j, "Enabled", ct.enabled);
-}
-
 static void from_json(const json& j, ColorToggleRounding& ctr)
 {
     from_json(j, static_cast<ColorToggle&>(ctr));

--- a/Osiris/ConfigStructs.h
+++ b/Osiris/ConfigStructs.h
@@ -386,6 +386,12 @@ static void from_json(const json& j, Color3& c)
     read(j, "Rainbow Speed", c.rainbowSpeed);
 }
 
+static void from_json(const json& j, ColorToggle3& ct)
+{
+    from_json(j, static_cast<Color3&>(ct));
+    read(j, "Enabled", ct.enabled);
+}
+
 static void from_json(const json& j, HealthBar& o)
 {
     from_json(j, static_cast<ColorToggle&>(o));


### PR DESCRIPTION
Found that "Bomb timer" option doesn't enabled after config loading, although correctly written to config. Found a race condition for `read<value_t::object>`, fixed by moving `static void from_json(const json& j, ColorToggle3& ct)` to `ConfigStruct.h`