### PR TITLE
Fix visibility check with glow while dead

### DIFF
--- a/Osiris/SDK/Entity.cpp
+++ b/Osiris/SDK/Entity.cpp
@@ -114,10 +114,14 @@ bool Entity::visibleTo(Entity* other) noexcept
 {
     assert(isAlive());
 
-    if (other->canSee(this, getAbsOrigin() + Vector{ 0.0f, 0.0f, 5.0f }))
+    Entity* targetEntity = other;
+    if (!other->isAlive() && other->getObserverTarget())
+        targetEntity = other->getObserverTarget();
+
+    if (targetEntity->canSee(this, getAbsOrigin() + Vector{ 0.0f, 0.0f, 5.0f }))
         return true;
 
-    if (other->canSee(this, getEyePosition() + Vector{ 0.0f, 0.0f, 5.0f }))
+    if (targetEntity->canSee(this, getEyePosition() + Vector{ 0.0f, 0.0f, 5.0f }))
         return true;
 
     const auto model = getModel();
@@ -138,7 +142,7 @@ bool Entity::visibleTo(Entity* other) noexcept
 
     for (const auto boxNum : { Hitbox::Belly, Hitbox::LeftForearm, Hitbox::RightForearm }) {
         const auto hitbox = set->getHitbox(boxNum);
-        if (hitbox && other->canSee(this, boneMatrices[hitbox->bone].origin()))
+        if (hitbox && targetEntity->canSee(this, boneMatrices[hitbox->bone].origin()))
             return true;
     }
 


### PR DESCRIPTION
This is just a small issue I noticed with the cheat a few months ago that hasn't been fixed. This seems to fix everything, the problem here occurs when you have glow enabled with separate colors for visibility, and while spectating localplayer can't see the player, but the player you are spectating can. This is kind of hard to explain, but in bot games with fixes the problem completely. If you need further explanation or if I missed something, please leave a comment.

Thanks!