### PR TITLE
Enable precompiled headers on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.0)
+cmake_minimum_required(VERSION 3.16.0)
 project(Osiris)
 
 set(CMAKE_C_FLAGS_RELEASE "-O3 -fvisibility=hidden -flto -fno-exceptions -DNDEBUG -Wfatal-errors")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,5 +27,6 @@ find_package(OpenGL REQUIRED)
 add_library(Osiris SHARED ${SOURCES})
 
 target_include_directories(Osiris PRIVATE ${SDL2_INCLUDE_DIRS} ${FREETYPE_INCLUDE_DIRS})
+target_precompile_headers(Osiris PRIVATE "${CMAKE_SOURCE_DIR}/Osiris/pch.h")
 target_link_libraries(Osiris PRIVATE SDL2 GL ${CMAKE_DL_LIBS} Freetype::Freetype)
 target_link_options(Osiris PRIVATE LINKER:--no-undefined)


### PR DESCRIPTION
Probably this was should be added to #2841 but i forgot about that PR. Anyway, here is little patch to enable compilation of PCH on CMake builds