### PR TITLE
Update memory->insertIntoTree pattern for Linux

### DIFF
--- a/Osiris/Interfaces.h
+++ b/Osiris/Interfaces.h
@@ -8,6 +8,8 @@
 #include <Windows.h>
 #else
 #include <dlfcn.h>
+
+#include <SDL2/SDL_messagebox.h>
 #endif
 
 #include "SDK/Platform.h"
@@ -82,6 +84,8 @@ private:
 
 #ifdef _WIN32
         MessageBoxA(nullptr, ("Failed to find " + std::string{ name } + " interface!").c_str(), "Osiris", MB_OK | MB_ICONERROR);
+#else
+        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Osiris", ("Failed to find " + std::string{ name } + " interface!").c_str(), NULL);
 #endif
         std::exit(EXIT_FAILURE);
     }

--- a/Osiris/Memory.cpp
+++ b/Osiris/Memory.cpp
@@ -15,6 +15,8 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#include <SDL2/SDL_messagebox.h>
 #endif
 
 #include "Interfaces.h"
@@ -129,9 +131,11 @@ static std::uintptr_t findPattern(const char* moduleName, std::string_view patte
     }
 
     assert(false);
-#ifdef _WIN32
     if (reportNotFound)
-        MessageBoxA(nullptr, ("Failed to find pattern #" + std::to_string(id) + '!').c_str(), "Osiris", MB_OK | MB_ICONWARNING);
+#ifdef _WIN32
+    MessageBoxA(nullptr, ("Failed to find pattern #" + std::to_string(id) + '!').c_str(), "Osiris", MB_OK | MB_ICONWARNING);
+#else
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Osiris", ("Failed to find pattern #" + std::to_string(id) + '!').c_str(), NULL);
 #endif
     return 0;
 }

--- a/Osiris/Memory.cpp
+++ b/Osiris/Memory.cpp
@@ -301,7 +301,7 @@ Memory::Memory() noexcept
     deleteItemGetArgAsStringReturnAddress = findPattern(CLIENT_DLL, "\x48\x85\xC0\x74\xDE\x48\x89\xC7\xE8????\x48\x89\xC3\xE8????\x48\x89\xDE");
     setDynamicAttributeValueFn = findPattern(CLIENT_DLL, "\x41\x8B\x06\x49\x8D\x7D\x08") - 95;
     createBaseTypeCache = relativeToAbsolute<decltype(createBaseTypeCache)>(findPattern(CLIENT_DLL, "\xE8????\x48\x89\xDE\x5B\x48\x8B\x10") + 1);
-    insertIntoTree = findPattern(CLIENT_DLL, "\x74\x2A\x4C\x8B\x10") + 31;
+    insertIntoTree = findPattern(CLIENT_DLL, "\x74\x24\x4C\x8B\x10") + 31;
     uiComponentInventory = relativeToAbsolute<decltype(uiComponentInventory)>(findPattern(CLIENT_DLL, "\xE8????\x4C\x89\x3D????\x4C\x89\xFF\xEB\x9E") + 8);
     setItemSessionPropertyValue = relativeToAbsolute<decltype(setItemSessionPropertyValue)>(findPattern(CLIENT_DLL, "\xE8????\x48\x8B\x85????\x41\x83\xC4\x01") + 1);
 


### PR DESCRIPTION
Hooks::listLeavesInBox() and Misc::shouldDisableModelOcclusion() was broken for a probably a long time due a silence nature of this fault. Found new signature and corrected it.

P.S. Only now, during pull request creation, i realized that just one byte has been changed so, maybe, its a good candidate to be replaced with "?" symbol for future-proof? I am new to such low-level stuff and don't fully understand when and why it need to be used.