### PR TITLE
Use reference type to prevent copying

### DIFF
--- a/Osiris/InventoryChanger/Inventory.cpp
+++ b/Osiris/InventoryChanger/Inventory.cpp
@@ -284,7 +284,7 @@ private:
 
     void _addItems() noexcept
     {
-        for (const auto [index, dynamicDataIndex, asUnacknowledged] : toAdd)
+        for (const auto& [index, dynamicDataIndex, asUnacknowledged] : toAdd)
             _addItem(index, dynamicDataIndex, asUnacknowledged);
         toAdd.clear();
     }


### PR DESCRIPTION
Small fix to take items details by reference instead of unnecessary copying.