### PR TITLE
Using std::make_unique_for_overwrite() for more efficiency

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -624,7 +624,7 @@ static auto getFontData(const std::string& fontName) noexcept
             dataSize = GetFontData(hdc, 0, 0, nullptr, 0);
 
             if (dataSize != GDI_ERROR) {
-                data = std::make_unique<std::byte[]>(dataSize);
+                data = std::make_unique_for_overwrite<std::byte[]>(dataSize);
                 dataSize = GetFontData(hdc, 0, 0, data.get(), dataSize);
 
                 if (dataSize == GDI_ERROR)

--- a/Osiris/GameData.cpp
+++ b/Osiris/GameData.cpp
@@ -398,7 +398,7 @@ PlayerData::PlayerData(Entity* entity) noexcept : BaseData{ entity }, handle{ en
         constexpr auto rgbaDataSize = 4 * 32 * 32;
 
         PlayerAvatar playerAvatar;
-        playerAvatar.rgba = std::make_unique<std::uint8_t[]>(rgbaDataSize);
+        playerAvatar.rgba = std::make_unique_for_overwrite<std::uint8_t[]>(rgbaDataSize);
         if (ctx->steamUtils->getImageRGBA(avatar, playerAvatar.rgba.get(), rgbaDataSize))
             playerAvatars[handle] = std::move(playerAvatar);
     }

--- a/Osiris/Hooks/MinHook.cpp
+++ b/Osiris/Hooks/MinHook.cpp
@@ -5,7 +5,7 @@
 void MinHook::init(void* base) noexcept
 {
     this->base = base;
-    originals = std::make_unique<uintptr_t[]>(Helpers::calculateVmtLength(*reinterpret_cast<uintptr_t**>(base)));
+    originals = std::make_unique_for_overwrite<uintptr_t[]>(Helpers::calculateVmtLength(*reinterpret_cast<uintptr_t**>(base)));
 }
 
 void MinHook::hookAt(std::size_t index, void* fun) noexcept

--- a/Osiris/Hooks/VmtHook.cpp
+++ b/Osiris/Hooks/VmtHook.cpp
@@ -12,7 +12,7 @@ void VmtHook::init(void* base) noexcept
     this->base = base;
     auto vmt = *reinterpret_cast<std::uintptr_t**>(base);
     length = Helpers::calculateVmtLength(vmt);
-    oldVmt = std::make_unique<std::uintptr_t[]>(length);
+    oldVmt = std::make_unique_for_overwrite<std::uintptr_t[]>(length);
     std::copy(vmt, vmt + length, oldVmt.get());
 }
 

--- a/Osiris/Hooks/VmtSwap.cpp
+++ b/Osiris/Hooks/VmtSwap.cpp
@@ -8,7 +8,7 @@ void VmtSwap::init(void* base) noexcept
     this->base = base;
     oldVmt = *reinterpret_cast<std::uintptr_t**>(base);
     std::size_t length = Helpers::calculateVmtLength(oldVmt) + dynamicCastInfoLength;
-    newVmt = std::make_unique<std::uintptr_t[]>(length);
+    newVmt = std::make_unique_for_overwrite<std::uintptr_t[]>(length);
     std::copy(oldVmt - dynamicCastInfoLength, oldVmt - dynamicCastInfoLength + length, newVmt.get());
     *reinterpret_cast<std::uintptr_t**>(base) = newVmt.get() + dynamicCastInfoLength;
 }

--- a/Osiris/InventoryChanger/InventoryChanger.cpp
+++ b/Osiris/InventoryChanger/InventoryChanger.cpp
@@ -1097,7 +1097,7 @@ static ImTextureID getItemIconTexture(const std::string& iconpath) noexcept
         assert(handle);
         if (handle) {
             if (const auto size = interfaces->baseFileSystem->size(handle); size > 0) {
-                const auto buffer = std::make_unique<std::uint8_t[]>(size);
+                const auto buffer = std::make_unique_for_overwrite<std::uint8_t[]>(size);
                 if (interfaces->baseFileSystem->read(buffer.get(), size, handle) > 0) {
                     int width, height;
                     stbi_set_flip_vertically_on_load_thread(false);


### PR DESCRIPTION
We don't need to zero-initialize heap memory if we are going to overwrite it immediately. For sure, it have a little sense for stuff like hooks and fonts, changed only for consistency. But it doing a real deal with PlayerAvatar initialization in PlayerData::PlayerData(). With "std::make_unique" i got microstutters on large casual publics everytime when new player connected and new avatar getting cached. With "std::make_unique_for_overwrite()" it's a lot less, almost unnoticeable.

Btw, as we have constant rgbaDataSize i've tried to replace heap allocation with std::array but got extreme stutters on avatars downloading. Probably because lack of move operation for std::array.