### PR TITLE
Avoid zero-initialization of memory areas for for more efficiency

### DIFF
--- a/Osiris/GameData.cpp
+++ b/Osiris/GameData.cpp
@@ -398,7 +398,7 @@ PlayerData::PlayerData(Entity* entity) noexcept : BaseData{ entity }, handle{ en
         constexpr auto rgbaDataSize = 4 * 32 * 32;
 
         PlayerAvatar playerAvatar;
-        playerAvatar.rgba = std::make_unique<std::uint8_t[]>(rgbaDataSize);
+        playerAvatar.rgba = std::unique_ptr<std::uint8_t[]>(new std::uint8_t[rgbaDataSize]);
         if (ctx->steamUtils->getImageRGBA(avatar, playerAvatar.rgba.get(), rgbaDataSize))
             playerAvatars[handle] = std::move(playerAvatar);
     }

--- a/Osiris/InventoryChanger/InventoryChanger.cpp
+++ b/Osiris/InventoryChanger/InventoryChanger.cpp
@@ -1097,7 +1097,7 @@ static ImTextureID getItemIconTexture(const std::string& iconpath) noexcept
         assert(handle);
         if (handle) {
             if (const auto size = interfaces->baseFileSystem->size(handle); size > 0) {
-                const auto buffer = std::make_unique<std::uint8_t[]>(size);
+                const auto buffer = std::unique_ptr<std::uint8_t[]>(new std::uint8_t[size]);
                 if (interfaces->baseFileSystem->read(buffer.get(), size, handle) > 0) {
                     int width, height;
                     stbi_set_flip_vertically_on_load_thread(false);


### PR DESCRIPTION
Second version of #3324. Using plain "new"s instead of std::make_unique_for_overwrite and only for player avatars and weapon icons as it give measurable performance impact.
Some benchmark times:
**Caching new avatar (median):**

- make_unique: 0.0001175s
- new: 0.000057s

Loading weapon icons is hard to measure but anyway its a up to 9 unnecessary operations per frame on my PC.