### PR TITLE
Prevent inventory changer from applying agent skin in dangerzone

### DIFF
--- a/Osiris/InventoryChanger/InventoryChanger.cpp
+++ b/Osiris/InventoryChanger/InventoryChanger.cpp
@@ -30,6 +30,7 @@
 #include "../SDK/ConVar.h"
 #include "../SDK/Cvar.h"
 #include "../SDK/EconItemView.h"
+#include "../SDK/Engine.h"
 #include "../SDK/Entity.h"
 #include "../SDK/EntityList.h"
 #include "../SDK/FileSystem.h"
@@ -324,6 +325,9 @@ static void applyMusicKit(CSPlayerInventory& localInventory) noexcept
 
 static void applyPlayerAgent(CSPlayerInventory& localInventory) noexcept
 {
+    if (strncmp(interfaces->engine->getLevelName(), "dz", 2))
+        return;
+    
     if (!localPlayer)
         return;
 

--- a/Osiris/InventoryChanger/InventoryChanger.cpp
+++ b/Osiris/InventoryChanger/InventoryChanger.cpp
@@ -325,7 +325,7 @@ static void applyMusicKit(CSPlayerInventory& localInventory) noexcept
 
 static void applyPlayerAgent(CSPlayerInventory& localInventory) noexcept
 {
-    if (strncmp(interfaces->engine->getLevelName(), "dz", 2))
+    if (!strncmp(interfaces->engine->getLevelName(), "dz", 2))
         return;
     
     if (!localPlayer)


### PR DESCRIPTION
If agent skin was equipped while playing dangerzone, it will make player stuck in his place.
Normally, agent skins shouldn't be applied in this mode. also in "coop_" maps but I didn't test it in coop.