### PR TITLE
Linux: Unlock mouse cursor in GUI

### DIFF
--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -129,10 +129,10 @@ void GUI::handleToggle() noexcept
         open = !open;
         if (!open)
             interfaces->inputSystem->resetInputState();
-#ifndef _WIN32
-        ImGui::GetIO().MouseDrawCursor = gui->open;
-#endif
     }
+#ifndef _WIN32
+    ImGui::GetIO().MouseDrawCursor = gui->open;
+#endif
 }
 
 static void menuBarItem(const char* name, bool& enabled) noexcept

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -614,9 +614,9 @@ void Hooks::install() noexcept
 #endif
     }
 
-#ifdef _WIN32
     surface.hookAt(67, &lockCursor);
 
+#ifdef _WIN32
     if constexpr (std::is_same_v<HookType, MinHook>)
         MH_EnableHook(MH_ALL_HOOKS);
 #endif


### PR DESCRIPTION
Not sure if this nasty thing happened after some of recent updates or i just didn't notice it before, but currently when GUI opened in-game, mouse cursor become locked in middle of screen. I must close GUI, open game menu / console / chat window / etc to get a mouse pointer and only then i could open GUI and actually use it. Got fixed by moving lockCursor hook init outside of #ifdef _WIN32.

Also when cheat has been just injected and automatically opened GUI i often get stuck without any cursor at all until i click twice on Insert. Fixed by moving `ImGui::GetIO().MouseDrawCursor = gui->open;` outside of `if (Misc::isMenuKeyPressed())` scope, so that it draws/hides the cursor directly on GUI opening/closing instead of waiting on keypress.