### PR TITLE
Another variant of the damage list

### DIFF
--- a/Osiris/EventListener.cpp
+++ b/Osiris/EventListener.cpp
@@ -20,6 +20,7 @@ namespace
         {
             switch (fnv::hashRuntime(event->getName())) {
             case fnv::hash("round_start"):
+                Misc::damageList(event);
                 GameData::clearProjectileList();
                 Misc::preserveKillfeed(true);
                 [[fallthrough]];
@@ -31,11 +32,13 @@ namespace
                 InventoryChanger::overrideHudIcon(*event);
                 Misc::killMessage(*event);
                 Misc::killSound(*event);
+                Misc::damageList(event);
                 break;
             case fnv::hash("player_hurt"):
                 Misc::playHitSound(*event);
                 Visuals::hitEffect(event);
                 Visuals::hitMarker(event);
+                Misc::damageList(event);
                 break;
             case fnv::hash("vote_cast"):
                 Misc::voteRevealer(*event);

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -128,6 +128,16 @@ struct MiscConfig {
     };
 
     SpectatorList spectatorList;
+
+    struct DamageList {
+        bool enabled = false;
+        bool noTitleBar = false;
+        int maxRows = 3;
+        ImVec2 pos;
+        ImVec2 size{ 300.0f, 200.0f };
+    };
+    DamageList damageList;
+
     struct Watermark {
         bool enabled = false;
     };
@@ -337,6 +347,95 @@ void Misc::spectatorList() noexcept
     }
 
     ImGui::End();
+}
+
+void Misc::damageList(GameEvent* event) noexcept
+{
+    if (!miscConfig.damageList.enabled)
+        return;
+
+    static std::mutex mtx;
+    std::scoped_lock _{mtx};
+
+    static std::unordered_map<int, int> damageCount;
+
+    if (event) {
+        switch (fnv::hashRuntime(event->getName())) {
+        case fnv::hash("round_start"):
+            damageCount.clear();
+            break;
+        case fnv::hash("player_hurt"):
+            if (const auto localPlayerId = localPlayer ? localPlayer->getUserId() : 0; localPlayerId && event->getInt("attacker") == localPlayerId && event->getInt("userid") != localPlayerId)
+                if (const auto player = interfaces->entityList->getEntity(interfaces->engine->getPlayerForUserID(event->getInt("userid"))); player)
+                    damageCount[player->handle()] += event->getInt("dmg_health");
+            break;
+        case fnv::hash("player_death"):
+            if (const auto player = interfaces->entityList->getEntity(interfaces->engine->getPlayerForUserID(event->getInt("userid"))); player)
+                damageCount.erase(player->handle());
+            break;
+        }
+    } else {
+        if ((damageCount.empty() || !interfaces->engine->isInGame()) && !gui->isOpen())
+            return;
+
+        if (miscConfig.damageList.pos != ImVec2{}) {
+            ImGui::SetNextWindowPos(miscConfig.damageList.pos);
+            miscConfig.damageList.pos = {};
+        }
+
+        if (miscConfig.damageList.size != ImVec2{}) {
+            ImGui::SetNextWindowSize(ImClamp(miscConfig.damageList.size, {}, ImGui::GetIO().DisplaySize));
+            miscConfig.damageList.size = {};
+        }
+
+        ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoCollapse;
+        if (!gui->isOpen())
+            windowFlags |= ImGuiWindowFlags_NoInputs;
+        if (miscConfig.damageList.noTitleBar)
+            windowFlags |= ImGuiWindowFlags_NoTitleBar;
+
+        if (!gui->isOpen())
+            ImGui::PushStyleColor(ImGuiCol_TitleBg, ImGui::GetColorU32(ImGuiCol_TitleBgActive));
+
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowTitleAlign, {0.5f, 0.5f});
+        ImGui::Begin("Damage list", nullptr, windowFlags);
+        ImGui::PopStyleVar();
+
+        if (!gui->isOpen())
+            ImGui::PopStyleColor();
+
+        std::vector<std::pair<int, int>> damageList(damageCount.cbegin(), damageCount.cend());
+        std::ranges::sort(damageList, std::ranges::greater{}, &std::pair<int, int>::second);
+        GameData::Lock lock;
+
+        for (std::size_t rowsCount = 0; const auto &[handle, damage] : damageList) {
+            if (rowsCount >= miscConfig.damageList.maxRows)
+                break;
+
+            if (damage == 0)
+                continue;
+
+            if (const auto playerData = GameData::playerByHandle(handle)) {
+                if (playerData->health == 0)
+                    continue;
+
+                if (const auto texture = playerData->getAvatarTexture()) {
+                    const auto textSize = ImGui::CalcTextSize(playerData->name.c_str());
+                    ImGui::Image(texture, ImVec2(textSize.y, textSize.y), ImVec2(0, 0), ImVec2(1, 1), ImVec4(1, 1, 1, 1), ImVec4(1, 1, 1, 0.3f));
+                    ImGui::SameLine();
+                    ImGui::TextWrapped("%s: ", playerData->name.c_str());
+                    ImGui::SameLine(0.f, 1.f);
+                    if (!rowsCount)
+                        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 0, 0, 255));
+                    ImGui::TextWrapped("Dmg: %d | Health: %d", damage, playerData->health);
+                    if (!rowsCount)
+                        ImGui::PopStyleColor();
+                    ++rowsCount;
+                }
+            }
+        }
+        ImGui::End();
+    }
 }
 
 static void drawCrosshair(ImDrawList* drawList, const ImVec2& pos, ImU32 color) noexcept
@@ -1355,6 +1454,23 @@ void Misc::drawGUI(bool contentOnly) noexcept
     }
     ImGui::PopID();
 
+    ImGui::Checkbox("Damage list", &miscConfig.damageList.enabled);
+    ImGui::SameLine();
+
+    ImGui::PushID("Damage list");
+    if (ImGui::Button("..."))
+        ImGui::OpenPopup("");
+
+    if (ImGui::BeginPopup("")) {
+        ImGui::Checkbox("No Title Bar", &miscConfig.damageList.noTitleBar);
+        miscConfig.damageList.maxRows = std::clamp(miscConfig.damageList.maxRows, 1, 64);
+        ImGui::PushItemWidth(100.0f);
+        ImGui::InputInt("Maximum rows", &miscConfig.damageList.maxRows);
+        ImGui::PopItemWidth();
+        ImGui::EndPopup();
+    }
+    ImGui::PopID();
+
     ImGui::Checkbox("Watermark", &miscConfig.watermark.enabled);
     ImGuiCustom::colorPicker("Offscreen Enemies", miscConfig.offscreenEnemies.asColor4(), &miscConfig.offscreenEnemies.enabled);
     ImGui::SameLine();
@@ -1543,6 +1659,15 @@ static void from_json(const json& j, MiscConfig::SpectatorList& sl)
     read<value_t::object>(j, "Size", sl.size);
 }
 
+static void from_json(const json& j, MiscConfig::DamageList& dl)
+{
+    read(j, "Enabled", dl.enabled);
+    read(j, "No Title Bar", dl.noTitleBar);
+    read<value_t::object>(j, "Pos", dl.pos);
+    read<value_t::object>(j, "Size", dl.size);
+    read(j, "Max rows", dl.maxRows);
+}
+
 static void from_json(const json& j, MiscConfig::Watermark& o)
 {
     read(j, "Enabled", o.enabled);
@@ -1581,6 +1706,7 @@ static void from_json(const json& j, MiscConfig& m)
     read(j, "Reveal suspect", m.revealSuspect);
     read(j, "Reveal votes", m.revealVotes);
     read<value_t::object>(j, "Spectator list", m.spectatorList);
+    read<value_t::object>(j, "Damage list", m.damageList);
     read<value_t::object>(j, "Watermark", m.watermark);
     read<value_t::object>(j, "Offscreen Enemies", m.offscreenEnemies);
     read(j, "Fix animation LOD", m.fixAnimationLOD);
@@ -1676,6 +1802,18 @@ static void to_json(json& j, const MiscConfig::SpectatorList& o, const MiscConfi
     }
 }
 
+static void to_json(json& j, const MiscConfig::DamageList& o, const MiscConfig::DamageList& dummy = {})
+{
+    WRITE("Enabled", enabled);
+    WRITE("No Title Bar", noTitleBar);
+    WRITE("Max rows", maxRows);
+
+    if (const auto window = ImGui::FindWindowByName("Damage list")) {
+        j["Pos"] = window->Pos;
+        j["Size"] = window->SizeFull;
+    }
+}
+
 static void to_json(json& j, const MiscConfig::Watermark& o, const MiscConfig::Watermark& dummy = {})
 {
     WRITE("Enabled", enabled);
@@ -1719,6 +1857,7 @@ static void to_json(json& j, const MiscConfig& o)
     WRITE("Reveal suspect", revealSuspect);
     WRITE("Reveal votes", revealVotes);
     WRITE("Spectator list", spectatorList);
+    WRITE("Damage list", damageList);
     WRITE("Watermark", watermark);
     WRITE("Offscreen Enemies", offscreenEnemies);
     WRITE("Fix animation LOD", fixAnimationLOD);

--- a/Osiris/Hacks/Misc.h
+++ b/Osiris/Hacks/Misc.h
@@ -22,6 +22,7 @@ namespace Misc
     void slowwalk(UserCmd* cmd) noexcept;
     void updateClanTag(bool = false) noexcept;
     void spectatorList() noexcept;
+    void damageList(GameEvent* event = nullptr) noexcept;
     void noscopeCrosshair(ImDrawList* drawlist) noexcept;
     void recoilCrosshair(ImDrawList* drawList) noexcept;
     void watermark() noexcept;

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -132,6 +132,7 @@ static void swapWindow(SDL_Window * window) noexcept
         Misc::drawOffscreenEnemies(ImGui::GetBackgroundDrawList());
         Misc::drawBombTimer();
         Misc::spectatorList();
+        Misc::damageList();
         Visuals::hitMarker(nullptr, ImGui::GetBackgroundDrawList());
         Visuals::drawMolotovHull(ImGui::GetBackgroundDrawList());
         Misc::watermark();


### PR DESCRIPTION
Inspired by previous PRs like #3178 but show only damage given by local player to enemies, show how much HP left and doesn't crash because of correctly usage of mutex locks. I think its enough useful for legit play to be pulled in.