### PR TITLE
Fix recoil crosshair on pistols

### DIFF
--- a/Osiris/GameData.cpp
+++ b/Osiris/GameData.cpp
@@ -300,9 +300,9 @@ void LocalPlayerData::update() noexcept
 
     if (const auto activeWeapon = localPlayer->getActiveWeapon()) {
         inReload = activeWeapon->isInReload();
-        shooting = localPlayer->shotsFired() > 1;
         noScope = activeWeapon->isSniperRifle() && !localPlayer->isScoped();
         nextWeaponAttack = activeWeapon->nextPrimaryAttack();
+        shooting = activeWeapon->isPistol() ? !inReload && nextWeaponAttack > memory->globalVars->serverTime() : localPlayer->shotsFired() > 1;
     }
     fov = localPlayer->fov() ? localPlayer->fov() : localPlayer->defaultFov();
     handle = localPlayer->handle();


### PR DESCRIPTION
Unlike old version (via CVar), the current one doesn't work on pistols because `localPlayer->shotsFired() > 1` check is never true on them. Added an alternative check for pistols. Its really useful, especially for dual berettas with autopistol.