### PR TITLE
Better flCurrentDistance estimation.

### DIFF
--- a/Source/Hacks/Aimbot.cpp
+++ b/Source/Hacks/Aimbot.cpp
@@ -97,7 +97,8 @@ static bool canScan(Entity* entity, const Vector& destination, const WeaponInfo*
 
     Vector start{ localPlayer->getEyePosition() };
     Vector direction{ destination - start };
-    direction /= direction.length();
+    float distance{ direction.length() };
+    direction /= distance;
 
     int hitsLeft = 4;
 
@@ -112,7 +113,7 @@ static bool canScan(Entity* entity, const Vector& destination, const WeaponInfo*
             break;
 
         if (trace.entity == entity && trace.hitgroup > HitGroup::Generic && trace.hitgroup <= HitGroup::RightLeg) {
-            damage = HitGroup::getDamageMultiplier(trace.hitgroup) * damage * std::pow(weaponData->rangeModifier, trace.fraction * weaponData->range / 500.0f);
+            damage = HitGroup::getDamageMultiplier(trace.hitgroup) * damage * std::pow(weaponData->rangeModifier, distance / 500.0f);
 
             if (float armorRatio{ weaponData->armorRatio / 2.0f }; HitGroup::isArmored(trace.hitgroup, trace.entity->hasHelmet()))
                 damage -= (trace.entity->armor() < damage * armorRatio / 2.0f ? trace.entity->armor() * 4.0f : damage) * (1.0f - armorRatio);


### PR DESCRIPTION
The game uses this code to calculate the damage dropoff based on the distance the bullet travelled. 
```cpp
fCurrentDamage *= pow (flRangeModifier, (flCurrentDistance / 500));
```

currently, to get `flCurrentDistance` you use `trace.fraction * weaponData->range`.

`trace.fraction` will be inaccurate because you're only using the fraction from the *last* ray trace,
and since you're only tracing to the other player, not extending the ray out to the max weapon range, 
`trace.fraction` will always be ~0.99 if the player is hit.

It's not perfect, but `(destination - start).length()` is a much better estimate of the distance the bullet will travel than `weaponData->range * ~0.99`