### PR TITLE
Fixed radar hack in FFA deathmatch

### DIFF
--- a/Source/Netvars.cpp
+++ b/Source/Netvars.cpp
@@ -24,18 +24,18 @@
 
 static std::unordered_map<std::uint32_t, std::pair<recvProxy, recvProxy*>> proxies;
 
-static void CDECL_CONV spottedHook(recvProxyData& data, void* arg2, void* arg3) noexcept
+static void CDECL_CONV spottedHook(recvProxyData& data, void* outStruct, void* arg3) noexcept
 {
+    const auto entity = reinterpret_cast<Entity*>(outStruct);
+
     if (Misc::isRadarHackOn()) {
         data.value._int = 1;
-
-        Entity* entity = (Entity *)arg2;
 
         entity->spottedByMask() |= 1 << (localPlayer->index() - 1);
     }
 
     constexpr auto hash{ fnv::hash("CBaseEntity->m_bSpotted") };
-    proxies[hash].first(data, arg2, arg3);
+    proxies[hash].first(data, outStruct, arg3);
 }
 
 static void CDECL_CONV viewModelSequence(recvProxyData& data, void* outStruct, void* arg3) noexcept

--- a/Source/Netvars.cpp
+++ b/Source/Netvars.cpp
@@ -31,7 +31,9 @@ static void CDECL_CONV spottedHook(recvProxyData& data, void* outStruct, void* a
     if (Misc::isRadarHackOn()) {
         data.value._int = 1;
 
-        entity->spottedByMask() |= 1 << (localPlayer->index() - 1);
+        if (localPlayer)
+            if (const auto index = localPlayer->index(); index > 0 && index <= 32)
+                entity->spottedByMask() |= 1 << (index - 1);
     }
 
     constexpr auto hash{ fnv::hash("CBaseEntity->m_bSpotted") };

--- a/Source/Netvars.cpp
+++ b/Source/Netvars.cpp
@@ -33,7 +33,7 @@ static void CDECL_CONV spottedHook(recvProxyData& data, void* arg2, void* arg3) 
         Entity* entity = (Entity *)arg2;
         int localPlayerIndex = interfaces->engine->getLocalPlayer();
 
-        entity->spottedByMask() = 1 << (localPlayerIndex - 1);
+        entity->spottedByMask() |= 1 << (localPlayerIndex - 1);
     }
 
     constexpr auto hash{ fnv::hash("CBaseEntity->m_bSpotted") };

--- a/Source/Netvars.cpp
+++ b/Source/Netvars.cpp
@@ -16,6 +16,7 @@
 #include "SDK/Constants/ClassId.h"
 #include "SDK/Client.h"
 #include "SDK/ClientClass.h"
+#include "SDK/Engine.h"
 #include "SDK/Entity.h"
 #include "SDK/EntityList.h"
 #include "SDK/LocalPlayer.h"
@@ -26,8 +27,14 @@ static std::unordered_map<std::uint32_t, std::pair<recvProxy, recvProxy*>> proxi
 
 static void CDECL_CONV spottedHook(recvProxyData& data, void* arg2, void* arg3) noexcept
 {
-    if (Misc::isRadarHackOn())
+    if (Misc::isRadarHackOn()) {
         data.value._int = 1;
+
+        Entity* entity = (Entity *)arg2;
+        int localPlayerIndex = interfaces->engine->getLocalPlayer();
+
+        entity->spottedByMask() = 1 << (localPlayerIndex - 1);
+    }
 
     constexpr auto hash{ fnv::hash("CBaseEntity->m_bSpotted") };
     proxies[hash].first(data, arg2, arg3);

--- a/Source/Netvars.cpp
+++ b/Source/Netvars.cpp
@@ -16,7 +16,6 @@
 #include "SDK/Constants/ClassId.h"
 #include "SDK/Client.h"
 #include "SDK/ClientClass.h"
-#include "SDK/Engine.h"
 #include "SDK/Entity.h"
 #include "SDK/EntityList.h"
 #include "SDK/LocalPlayer.h"
@@ -31,9 +30,8 @@ static void CDECL_CONV spottedHook(recvProxyData& data, void* arg2, void* arg3) 
         data.value._int = 1;
 
         Entity* entity = (Entity *)arg2;
-        int localPlayerIndex = interfaces->engine->getLocalPlayer();
 
-        entity->spottedByMask() |= 1 << (localPlayerIndex - 1);
+        entity->spottedByMask() |= 1 << (localPlayer->index() - 1);
     }
 
     constexpr auto hash{ fnv::hash("CBaseEntity->m_bSpotted") };

--- a/Source/SDK/Engine.h
+++ b/Source/SDK/Engine.h
@@ -58,6 +58,7 @@ public:
     VIRTUAL_METHOD(void, getScreenSize, 5, (int& w, int& h), (this, std::ref(w), std::ref(h)))
     VIRTUAL_METHOD(bool, getPlayerInfo, 8, (int entityIndex, PlayerInfo& playerInfo), (this, entityIndex, std::ref(playerInfo)))
     VIRTUAL_METHOD(int, getPlayerForUserID, 9, (int userId), (this, userId))
+    VIRTUAL_METHOD(int, getLocalPlayer, 12, (), (this))
     VIRTUAL_METHOD(void, getViewAngles, 18, (Vector& angles), (this, std::ref(angles)))
     VIRTUAL_METHOD(void, setViewAngles, 19, (const Vector& angles), (this, std::cref(angles)))
     VIRTUAL_METHOD(int, getMaxClients, 20, (), (this))

--- a/Source/SDK/Engine.h
+++ b/Source/SDK/Engine.h
@@ -58,7 +58,6 @@ public:
     VIRTUAL_METHOD(void, getScreenSize, 5, (int& w, int& h), (this, std::ref(w), std::ref(h)))
     VIRTUAL_METHOD(bool, getPlayerInfo, 8, (int entityIndex, PlayerInfo& playerInfo), (this, entityIndex, std::ref(playerInfo)))
     VIRTUAL_METHOD(int, getPlayerForUserID, 9, (int userId), (this, userId))
-    VIRTUAL_METHOD(int, getLocalPlayer, 12, (), (this))
     VIRTUAL_METHOD(void, getViewAngles, 18, (Vector& angles), (this, std::ref(angles)))
     VIRTUAL_METHOD(void, setViewAngles, 19, (const Vector& angles), (this, std::cref(angles)))
     VIRTUAL_METHOD(int, getMaxClients, 20, (), (this))

--- a/Source/SDK/Entity.h
+++ b/Source/SDK/Entity.h
@@ -179,6 +179,7 @@ public:
     NETVAR(simulationTime, "CBaseEntity", "m_flSimulationTime", float)
     NETVAR(ownerEntity, "CBaseEntity", "m_hOwnerEntity", int)
     NETVAR(spotted, "CBaseEntity", "m_bSpotted", bool)
+    NETVAR(spottedByMask, "CBaseEntity", "m_bSpottedByMask", int)
 
     NETVAR(weapons, "CBaseCombatCharacter", "m_hMyWeapons", int[64])
     PNETVAR(wearables, "CBaseCombatCharacter", "m_hMyWearables", int)

--- a/Source/SDK/Entity.h
+++ b/Source/SDK/Entity.h
@@ -179,7 +179,7 @@ public:
     NETVAR(simulationTime, "CBaseEntity", "m_flSimulationTime", float)
     NETVAR(ownerEntity, "CBaseEntity", "m_hOwnerEntity", int)
     NETVAR(spotted, "CBaseEntity", "m_bSpotted", bool)
-    NETVAR(spottedByMask, "CBaseEntity", "m_bSpottedByMask", int)
+    NETVAR(spottedByMask, "CBaseEntity", "m_bSpottedByMask", std::uint32_t)
 
     NETVAR(weapons, "CBaseCombatCharacter", "m_hMyWeapons", int[64])
     PNETVAR(wearables, "CBaseCombatCharacter", "m_hMyWearables", int)


### PR DESCRIPTION
This patch makes entities spotted by local player. It is required for radar hack to work in Free For All deathmatch.