### PR TITLE
Reduce number of calls of Netvars::get

### DIFF
--- a/Source/Netvars.h
+++ b/Source/Netvars.h
@@ -30,15 +30,15 @@ namespace Netvars
 #define PNETVAR_OFFSET(funcname, class_name, var_name, offset, type) \
 [[nodiscard]] auto funcname() noexcept \
 { \
-    constexpr auto hash = fnv::hash(class_name "->" var_name); \
-    return reinterpret_cast<std::add_pointer_t<type>>(std::uintptr_t(this) + Netvars::get(hash) + offset); \
+    static auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
+    return reinterpret_cast<std::add_pointer_t<type>>(std::uintptr_t(this) + netvarOffset + offset); \
 }
 
 #define PNETVAR_OFFSET2(funcname, class_name, var_name, offset, type) \
 [[nodiscard]] auto funcname() const noexcept \
 { \
-    constexpr auto hash = fnv::hash(class_name "->" var_name); \
-    return reinterpret_cast<std::add_pointer_t<type>>(getThis() + Netvars::get(hash) + offset); \
+    static auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
+    return reinterpret_cast<std::add_pointer_t<type>>(getThis() + netvarOffset + offset); \
 }
 
 #define PNETVAR(funcname, class_name, var_name, type) \
@@ -50,15 +50,15 @@ namespace Netvars
 #define NETVAR_OFFSET(funcname, class_name, var_name, offset, type) \
 [[nodiscard]] std::add_lvalue_reference_t<type> funcname() noexcept \
 { \
-    constexpr auto hash = fnv::hash(class_name "->" var_name); \
-    return *reinterpret_cast<std::add_pointer_t<type>>(std::uintptr_t(this) + Netvars::get(hash) + offset); \
+    static auto netvarOffset =  Netvars::get(fnv::hash(class_name "->" var_name)); \
+    return *reinterpret_cast<std::add_pointer_t<type>>(std::uintptr_t(this) + netvarOffset + offset); \
 }
 
 #define NETVAR_OFFSET2(funcname, class_name, var_name, offset, type) \
 [[nodiscard]] std::add_lvalue_reference_t<type> funcname() const noexcept \
 { \
-    constexpr auto hash = fnv::hash(class_name "->" var_name); \
-    return *reinterpret_cast<std::add_pointer_t<type>>(getThis() + Netvars::get(hash) + offset); \
+    static auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
+    return *reinterpret_cast<std::add_pointer_t<type>>(getThis() + netvarOffset + offset); \
 }
 
 #define NETVAR(funcname, class_name, var_name, type) \

--- a/Source/Netvars.h
+++ b/Source/Netvars.h
@@ -50,7 +50,7 @@ namespace Netvars
 #define NETVAR_OFFSET(funcname, class_name, var_name, offset, type) \
 [[nodiscard]] std::add_lvalue_reference_t<type> funcname() noexcept \
 { \
-    static const auto netvarOffset =  Netvars::get(fnv::hash(class_name "->" var_name)); \
+    static const auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
     return *reinterpret_cast<std::add_pointer_t<type>>(std::uintptr_t(this) + netvarOffset + offset); \
 }
 

--- a/Source/Netvars.h
+++ b/Source/Netvars.h
@@ -30,14 +30,14 @@ namespace Netvars
 #define PNETVAR_OFFSET(funcname, class_name, var_name, offset, type) \
 [[nodiscard]] auto funcname() noexcept \
 { \
-    static auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
+    static const auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
     return reinterpret_cast<std::add_pointer_t<type>>(std::uintptr_t(this) + netvarOffset + offset); \
 }
 
 #define PNETVAR_OFFSET2(funcname, class_name, var_name, offset, type) \
 [[nodiscard]] auto funcname() const noexcept \
 { \
-    static auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
+    static const auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
     return reinterpret_cast<std::add_pointer_t<type>>(getThis() + netvarOffset + offset); \
 }
 
@@ -50,14 +50,14 @@ namespace Netvars
 #define NETVAR_OFFSET(funcname, class_name, var_name, offset, type) \
 [[nodiscard]] std::add_lvalue_reference_t<type> funcname() noexcept \
 { \
-    static auto netvarOffset =  Netvars::get(fnv::hash(class_name "->" var_name)); \
+    static const auto netvarOffset =  Netvars::get(fnv::hash(class_name "->" var_name)); \
     return *reinterpret_cast<std::add_pointer_t<type>>(std::uintptr_t(this) + netvarOffset + offset); \
 }
 
 #define NETVAR_OFFSET2(funcname, class_name, var_name, offset, type) \
 [[nodiscard]] std::add_lvalue_reference_t<type> funcname() const noexcept \
 { \
-    static auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
+    static const auto netvarOffset = Netvars::get(fnv::hash(class_name "->" var_name)); \
     return *reinterpret_cast<std::add_pointer_t<type>>(getThis() + netvarOffset + offset); \
 }
 


### PR DESCRIPTION
Since offsets are constant there is no need to find them for every netvar call, just once is enough.