### PR TITLE
Add Explicit Includes in most headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,6 @@ ASALocalRun/
 
 # Local History for Visual Studio
 .localhistory/
+
+compile_commands.json
+.cache

--- a/Source/Entities/BaseEntity.h
+++ b/Source/Entities/BaseEntity.h
@@ -6,6 +6,8 @@
 #include <FeatureHelpers/LifeState.h>
 #include <FeatureHelpers/TeamNumber.h>
 #include <OutlineGlow/GlowSceneObjects.h>
+#include <FeatureHelpers/EntityClassifier.h>
+#include <MemoryPatterns/PatternTypes/EntityPatternTypes.h>
 
 #include <GameClasses/GameSceneNode.h>
 #include "RenderComponent.h"

--- a/Source/Entities/BaseModelEntity.h
+++ b/Source/Entities/BaseModelEntity.h
@@ -2,6 +2,7 @@
 
 #include <CS2/Classes/Entities/C_BaseModelEntity.h>
 #include <MemoryPatterns/PatternTypes/BaseModelEntityPatternTypes.h>
+#include <Entities/BaseEntity.h>
 
 #include "GlowProperty.h"
 

--- a/Source/Entities/BaseWeapon.h
+++ b/Source/Entities/BaseWeapon.h
@@ -3,6 +3,8 @@
 #include <CS2/Classes/Entities/C_CSWeaponBase.h>
 #include <CS2/Classes/CCSWeaponBaseVData.h>
 #include "BaseEntity.h"
+#include <MemoryPatterns/PatternTypes/WeaponVDataPatternTypes.h>
+#include <MemoryPatterns/PatternTypes/WeaponPatternTypes.h>
 
 template <typename HookContext>
 class BaseWeapon {

--- a/Source/Entities/C4.h
+++ b/Source/Entities/C4.h
@@ -2,6 +2,7 @@
 
 #include <CS2/Classes/Entities/WeaponEntities.h>
 #include "BaseWeapon.h"
+#include <MemoryPatterns/PatternTypes/C4PatternTypes.h>
 
 template <typename HookContext>
 class C4 {

--- a/Source/Entities/GameRules.h
+++ b/Source/Entities/GameRules.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <optional>
+#include <CS2/Classes/C_CSGameRules.h>
+#include <MemoryPatterns/PatternTypes/GameRulesPatternTypes.h>
 
 template <typename HookContext>
 class GameRules {

--- a/Source/Entities/GlowProperty.h
+++ b/Source/Entities/GlowProperty.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CS2/Classes/CGlowProperty.h>
+#include <MemoryPatterns/PatternTypes/GlowPropertyPatternTypes.h>
 
 template <typename HookContext>
 class GlowProperty {

--- a/Source/Entities/HostageServices.h
+++ b/Source/Entities/HostageServices.h
@@ -2,6 +2,7 @@
 
 #include <CS2/Classes/CCSPlayer_HostageServices.h>
 #include <GameClasses/EntitySystem.h>
+#include <MemoryPatterns/PatternTypes/HostageServicesPatternTypes.h>
 
 template <typename HookContext>
 class HostageServices {

--- a/Source/Entities/PlantedC4.h
+++ b/Source/Entities/PlantedC4.h
@@ -6,6 +6,7 @@
 #include <CS2/Constants/EntityHandle.h>
 #include <CS2/Constants/IconURLs.h>
 #include <GameClasses/GlobalVars.h>
+#include <MemoryPatterns/PatternTypes/PlantedC4PatternTypes.h>
 
 #include "BaseEntity.h"
 

--- a/Source/Entities/PlayerController.h
+++ b/Source/Entities/PlayerController.h
@@ -4,6 +4,8 @@
 #include <FeatureHelpers/TeamNumber.h>
 #include <GameClasses/EntitySystem.h>
 #include "PlayerPawn.h"
+#include <MemoryPatterns/PatternTypes/PlayerControllerPatternTypes.h>
+#include <CS2/Constants/ColorConstants.h>
 
 template <typename HookContext>
 class PlayerController {

--- a/Source/Entities/PlayerPawn.h
+++ b/Source/Entities/PlayerPawn.h
@@ -8,6 +8,8 @@
 #include <FeatureHelpers/TeamNumber.h>
 #include <GameClasses/GameSceneNode.h>
 #include <Utils/ColorUtils.h>
+#include <MemoryPatterns/PatternTypes/PlayerPawnPatternTypes.h>
+#include <CS2/Classes/ConVarTypes.h>
 
 #include "BaseEntity.h"
 #include "BaseModelEntity.h"

--- a/Source/Entities/RenderComponent.h
+++ b/Source/Entities/RenderComponent.h
@@ -2,6 +2,7 @@
 
 #include <CS2/Classes/CRenderComponent.h>
 #include <GameClasses/SceneObjectUpdaters.h>
+#include <MemoryPatterns/PatternTypes/RenderComponentPatternTypes.h>
 
 template <typename HookContext>
 class RenderComponent {

--- a/Source/Entities/SmokeGrenadeProjectile.h
+++ b/Source/Entities/SmokeGrenadeProjectile.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CS2/Classes/Entities/GrenadeProjectiles.h>
+#include <MemoryPatterns/PatternTypes/SmokeGrenadeProjectilePatternTypes.h>
 
 template <typename HookContext>
 class SmokeGrenadeProjectile {

--- a/Source/Entities/WeaponServices.h
+++ b/Source/Entities/WeaponServices.h
@@ -2,6 +2,7 @@
 
 #include <CS2/Classes/CCSPlayer_WeaponServices.h>
 #include <CS2/Classes/Entities/C_CSWeaponBase.h>
+#include <MemoryPatterns/PatternTypes/WeaponServicesPatternTypes.h>
 #include "BaseWeapon.h"
 #include "PlayerWeapons.h"
 

--- a/Source/FeatureHelpers/ConVarAccessor.h
+++ b/Source/FeatureHelpers/ConVarAccessor.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <optional>
+#include <cassert>
+#include <cstring>
 
 #include <GameDependencies/ConVars.h>
+#include <MemoryPatterns/PatternTypes/ConVarPatternTypes.h>
 
 struct ConVarAccessorState {
     std::optional<bool> mp_teammates_are_enemies;

--- a/Source/FeatureHelpers/EntityClassifier.h
+++ b/Source/FeatureHelpers/EntityClassifier.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <algorithm>
+#include <functional>
 #include <array>
 #include <cstdint>
 #include <limits>

--- a/Source/FeatureHelpers/FeatureToggle.h
+++ b/Source/FeatureHelpers/FeatureToggle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <Utils/PrivateTag.h>
 
 template <typename Feature, bool HasOnEnable, bool HasOnDisable>

--- a/Source/FeatureHelpers/Sound/SoundWatcherImpl.h
+++ b/Source/FeatureHelpers/Sound/SoundWatcherImpl.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstddef>
 #include <string_view>
 #include <tuple>
-#include <utility>
 
 #include <CS2/Classes/Sound.h>
 #include <GameClasses/FileSystem.h>
@@ -16,6 +14,7 @@
 #include <Utils/DynamicArray.h>
 #include <Utils/TypeBitFlags.h>
 #include <Utils/TypeIndex.h>
+#include <MemoryPatterns/PatternTypes/SoundSystemPatternTypes.h>
 
 #include "SoundExpiryChecker.h"
 #include "SoundWatcherImplState.h"

--- a/Source/FeatureHelpers/Sound/SoundWatcherImplState.h
+++ b/Source/FeatureHelpers/Sound/SoundWatcherImplState.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <array>
-#include <tuple>
 
 #include <Utils/TypeBitFlags.h>
 #include "WatchedSounds.h"

--- a/Source/FeatureHelpers/Sound/WatchedSounds.h
+++ b/Source/FeatureHelpers/Sound/WatchedSounds.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <utility>
 
 #include "PlayedSound.h"
 #include <Utils/DynamicArray.h>
@@ -21,7 +22,7 @@ public:
 
     [[nodiscard]] bool hasSound(int soundGuid) const noexcept
     {
-        // can not use std::ranges::find() because it tries to link with __std_find_trivial_4
+        // can not use std::ranges::find() because it tries to link with __std_find_trivial_4 (then why no use std::find)
         for (const auto guid : guids) {
             if (guid == soundGuid)
                 return true;

--- a/Source/FeatureHelpers/WorldToClipSpaceConverter.h
+++ b/Source/FeatureHelpers/WorldToClipSpaceConverter.h
@@ -5,6 +5,7 @@
 #include "ClipSpaceCoordinates.h"
 #include <CS2/Classes/Vector.h>
 #include <CS2/Classes/VMatrix.h>
+#include <MemoryPatterns/PatternTypes/ClientPatternTypes.h>
 
 template <typename HookContext>
 struct WorldToClipSpaceConverter {

--- a/Source/Features/Common/InWorldPanelsState.h
+++ b/Source/Features/Common/InWorldPanelsState.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <array>
 #include <CS2/Panorama/PanelHandle.h>
 #include <Utils/DynamicArray.h>
+#include <Features/Sound/SoundVisualizationPanelTypes.h>
 
 #include "InWorldPanelIndex.h"
 #include "InWorldPanelListEntry.h"

--- a/Source/Features/Hud/BombTimer/BombTimerContext.h
+++ b/Source/Features/Hud/BombTimer/BombTimerContext.h
@@ -11,7 +11,6 @@
 #include "BombTimerCondition.h"
 #include "BombTimerPanel.h"
 #include "BombTimerPanelFactory.h"
-#include "BombTimerState.h"
 #include "BombTimerTextPanel.h"
 
 template <typename HookContext>

--- a/Source/Features/Hud/BombTimer/BombTimerPanelParams.h
+++ b/Source/Features/Hud/BombTimer/BombTimerPanelParams.h
@@ -6,6 +6,7 @@
 #include <GameClasses/PanelAlignmentParams.h>
 #include <GameClasses/PanelFontParams.h>
 #include <GameClasses/PanelMarginParams.h>
+#include <CS2/Constants/ColorConstants.h>
 
 namespace bomb_timer_panel_params::container_panel_params
 {

--- a/Source/Features/Hud/BombTimer/BombTimerUnloadHandler.h
+++ b/Source/Features/Hud/BombTimer/BombTimerUnloadHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "BombTimerState.h"
+#include <GameClasses/PanoramaUiEngine.h>
 
 template <typename HookContext>
 struct BombTimerUnloadHandler {

--- a/Source/Features/Hud/DefusingAlert/DefusingAlertContext.h
+++ b/Source/Features/Hud/DefusingAlert/DefusingAlertContext.h
@@ -7,6 +7,8 @@
 #include "DefusingAlertPanelParams.h"
 #include "DefusingAlertState.h"
 #include "DefusingCountdownTextPanel.h"
+#include <GameClasses/PanoramaLabel.h>
+#include <GameClasses/PanoramaImagePanel.h>
 
 template <typename HookContext>
 class DefusingAlertContext {

--- a/Source/Features/Hud/DefusingAlert/DefusingAlertUnloadHandler.h
+++ b/Source/Features/Hud/DefusingAlert/DefusingAlertUnloadHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "DefusingAlertState.h"
+#include <GameClasses/PanoramaUiEngine.h>
 
 template <typename HookContext>
 struct DefusingAlertUnloadHandler {

--- a/Source/Features/Hud/KillfeedPreserver/KillfeedPreserver.h
+++ b/Source/Features/Hud/KillfeedPreserver/KillfeedPreserver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "KillfeedPreserverContext.h"
+#include <utility>
 
 template <typename HookContext, typename Context = KillfeedPreserverContext<HookContext>>
 class KillfeedPreserver {

--- a/Source/Features/Hud/PostRoundTimer/PostRoundTimerContext.h
+++ b/Source/Features/Hud/PostRoundTimer/PostRoundTimerContext.h
@@ -6,6 +6,7 @@
 #include "PostRoundTimerPanel.h"
 #include "PostRoundTimerPanelFactory.h"
 #include "PostRoundTimerState.h"
+#include <GameClasses/PanoramaLabel.h>
 
 template <typename HookContext>
 struct PostRoundTimerContext {

--- a/Source/Features/Hud/PostRoundTimer/PostRoundTimerPanel.h
+++ b/Source/Features/Hud/PostRoundTimer/PostRoundTimerPanel.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <FeatureHelpers/TeamNumber.h>
+#include <CS2/Constants/ColorConstants.h>
+#include <Utils/StringBuilder.h>
 
 template <typename Context>
 struct PostRoundTimerPanel {

--- a/Source/Features/Hud/PostRoundTimer/PostRoundTimerUnloadHandler.h
+++ b/Source/Features/Hud/PostRoundTimer/PostRoundTimerUnloadHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "PostRoundTimerState.h"
+#include <GameClasses/PanoramaUiEngine.h>
 
 template <typename HookContext>
 struct PostRoundTimerUnloadHandler {

--- a/Source/Features/Sound/Details/SoundVisualizationFeature.h
+++ b/Source/Features/Sound/Details/SoundVisualizationFeature.h
@@ -6,6 +6,8 @@
 #include <Hooks/ViewRenderHook.h>
 #include "SoundVisualization.h"
 #include "SoundVisualizationPanelFactory.h"
+#include <FeatureHelpers/WorldToClipSpaceConverter.h>
+#include <Features/Common/InWorldPanels.h>
 
 struct SoundVisualizationFeatureState {
     bool enabled{false};

--- a/Source/Features/Visuals/ModelGlow/ModelGlowState.h
+++ b/Source/Features/Visuals/ModelGlow/ModelGlowState.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <CS2/Classes/Entities/C_CSPlayerPawn.h>
+#include <CS2/Classes/Entities/C_CSWeaponBase.h>
 
 enum class PlayerModelGlowColorType : std::uint8_t {
     PlayerOrTeamColor,

--- a/Source/Features/Visuals/ModelGlow/ModelGlowToggle.h
+++ b/Source/Features/Visuals/ModelGlow/ModelGlowToggle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <FeatureHelpers/FeatureToggle.h>
+#include <Features/Visuals/ModelGlow/ModelGlowState.h>
 
 template <typename HookContext>
 class ModelGlowToggle {

--- a/Source/Features/Visuals/OutlineGlow/DefuseKitOutlineGlow/DefuseKitOutlineGlowToggle.h
+++ b/Source/Features/Visuals/OutlineGlow/DefuseKitOutlineGlow/DefuseKitOutlineGlowToggle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <FeatureHelpers/FeatureToggle.h>
 #include "DefuseKitOutlineGlowContext.h"
 

--- a/Source/Features/Visuals/OutlineGlow/HostageOutlineGlow/HostageOutlineGlowToggle.h
+++ b/Source/Features/Visuals/OutlineGlow/HostageOutlineGlow/HostageOutlineGlowToggle.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <FeatureHelpers/FeatureToggle.h>
-#include "HostageOutlineGlowContext.h"
+#include <Features/Visuals/OutlineGlow/GrenadeProjectileOutlineGlow/GrenadeProjectileOutlineGlowContext.h>
 
 template <typename HookContext, typename Context = GrenadeProjectileOutlineGlowContext<HookContext>>
 class HostageOutlineGlowToggle : public FeatureToggle<HostageOutlineGlowToggle<HookContext, Context>> {

--- a/Source/Features/Visuals/OutlineGlow/PlayerOutlineGlow/PlayerOutlineGlowToggle.h
+++ b/Source/Features/Visuals/OutlineGlow/PlayerOutlineGlow/PlayerOutlineGlowToggle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <FeatureHelpers/FeatureToggle.h>
 #include "PlayerOutlineGlowColorType.h"
 

--- a/Source/Features/Visuals/OutlineGlow/WeaponOutlineGlow/WeaponOutlineGlow.h
+++ b/Source/Features/Visuals/OutlineGlow/WeaponOutlineGlow/WeaponOutlineGlow.h
@@ -2,6 +2,7 @@
 
 #include <Features/Visuals/OutlineGlow/OutlineGlowParams.h>
 #include "WeaponOutlineGlowContext.h"
+#include <Entities/BaseEntity.h>
 
 template <typename HookContext, typename Context = WeaponOutlineGlowContext<HookContext>>
 class WeaponOutlineGlow {

--- a/Source/Features/Visuals/PlayerInfoInWorld/ActiveWeaponAmmo/PlayerActiveWeaponAmmoPanelContext.h
+++ b/Source/Features/Visuals/PlayerInfoInWorld/ActiveWeaponAmmo/PlayerActiveWeaponAmmoPanelContext.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Features/Visuals/PlayerInfoInWorld/PlayerInfoPanelCacheEntry.h>
+#include <CS2/Panorama/CUIPanel.h>
+#include <GameClasses/PanoramaUiPanel.h>
 
 template <typename HookContext>
 class PlayerActiveWeaponAmmoPanelContext {

--- a/Source/Features/Visuals/PlayerInfoInWorld/PlayerHealth/PlayerHealthPanelContext.h
+++ b/Source/Features/Visuals/PlayerInfoInWorld/PlayerHealth/PlayerHealthPanelContext.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Features/Visuals/PlayerInfoInWorld/PlayerInfoPanelCacheEntry.h>
+#include <CS2/Panorama/CUIPanel.h>
+#include <GameClasses/PanoramaUiPanel.h>
 
 template <typename HookContext>
 class PlayerHealthPanelContext {

--- a/Source/Features/Visuals/PlayerInfoInWorld/PlayerHealth/PlayerHealthPanelParams.h
+++ b/Source/Features/Visuals/PlayerInfoInWorld/PlayerHealth/PlayerHealthPanelParams.h
@@ -6,6 +6,7 @@
 #include <FeatureHelpers/PanelShadowParams.h>
 #include <GameClasses/PanelAlignmentParams.h>
 #include <GameClasses/PanelMarginParams.h>
+#include <GameClasses/PanelFontParams.h>
 
 namespace player_health_panel_params::container_panel_params
 {

--- a/Source/Features/Visuals/PlayerInfoInWorld/PlayerInfoInWorld.h
+++ b/Source/Features/Visuals/PlayerInfoInWorld/PlayerInfoInWorld.h
@@ -17,9 +17,6 @@
 #include <Utils/ColorUtils.h>
 #include <Utils/CString.h>
 
-#include "PlayerInfoPanel.h"
-
-#include "PlayerInfoInWorldPanelFactory.h"
 #include "PlayerInfoInWorldState.h"
 
 struct PlayerPositionToggle : public FeatureToggle<PlayerPositionToggle> {
@@ -195,7 +192,6 @@ private:
     ViewRenderHook& viewRenderHook;
 };
 
-#include "PlayerInfoInWorldCondition.h"
 #include "PlayerInfoInWorldContext.h"
 
 template <typename HookContext>

--- a/Source/Features/Visuals/PlayerInfoInWorld/PlayerPositionArrow/PlayerPositionArrowPanel.h
+++ b/Source/Features/Visuals/PlayerInfoInWorld/PlayerPositionArrow/PlayerPositionArrowPanel.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <utility>
 #include <FeatureHelpers/TeamNumber.h>
 
 #include "PlayerPositionArrowColorType.h"
 #include "PlayerPositionArrowPanelContext.h"
+#include <CS2/Constants/ColorConstants.h>
 
 template <typename HookContext, typename Context = PlayerPositionArrowPanelContext<HookContext>>
 class PlayerPositionArrowPanel {

--- a/Source/Features/Visuals/PlayerInfoInWorld/PlayerPositionArrow/PlayerPositionArrowPanelContext.h
+++ b/Source/Features/Visuals/PlayerInfoInWorld/PlayerPositionArrow/PlayerPositionArrowPanelContext.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Features/Visuals/PlayerInfoInWorld/PlayerInfoPanelCacheEntry.h>
+#include <CS2/Panorama/CUIPanel.h>
+#include <GameClasses/PanoramaUiPanel.h>
 
 template <typename HookContext>
 class PlayerPositionArrowPanelContext {

--- a/Source/Features/Visuals/PlayerInfoInWorld/PlayerWeaponIcon/ActiveWeaponIcon/PlayerActiveWeaponIconPanel.h
+++ b/Source/Features/Visuals/PlayerInfoInWorld/PlayerWeaponIcon/ActiveWeaponIcon/PlayerActiveWeaponIconPanel.h
@@ -5,6 +5,7 @@
 #include <GameClasses/PanoramaImagePanel.h>
 #include <Utils/CString.h>
 #include "PlayerActiveWeaponIconPanelContext.h"
+#include <Utils/StringBuilder.h>
 
 template <typename HookContext, typename Context = PlayerActiveWeaponIconPanelContext<HookContext>>
 class PlayerActiveWeaponIconPanel {

--- a/Source/GameClasses/EntitySystem.h
+++ b/Source/GameClasses/EntitySystem.h
@@ -6,6 +6,7 @@
 #include <CS2/Classes/EntitySystem/CEntityIndex.h>
 #include <CS2/Classes/EntitySystem/CGameEntitySystem.h>
 #include <MemoryPatterns/PatternTypes/EntitySystemPatternTypes.h>
+#include <cstring>
 
 template <typename HookContext>
 class EntitySystem {

--- a/Source/GameClasses/FileSystem.h
+++ b/Source/GameClasses/FileSystem.h
@@ -2,6 +2,7 @@
 
 #include <CS2/Classes/FileSystem.h>
 #include "FileNameSymbolTable.h"
+#include <MemoryPatterns/PatternTypes/FileSystemPatternTypes.h>
 
 template <typename HookContext>
 class FileSystem {

--- a/Source/GameClasses/GameSceneNode.h
+++ b/Source/GameClasses/GameSceneNode.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <CS2/Classes/CGameSceneNode.h>
+#include <CS2/Classes/Entities/C_BaseEntity.h>
+#include <MemoryPatterns/PatternTypes/GameSceneNodePatternTypes.h>
 
 template <typename HookContext>
 class BaseEntity;

--- a/Source/GameClasses/GlobalVars.h
+++ b/Source/GameClasses/GlobalVars.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Utils/Optional.h>
+#include <CS2/Classes/GlobalVars.h>
 
 struct GlobalVars {
     [[nodiscard]] Optional<float> curtime() const noexcept

--- a/Source/GameClasses/Hud/DeathNotice.h
+++ b/Source/GameClasses/Hud/DeathNotice.h
@@ -3,6 +3,7 @@
 #include <Utils/StringParser.h>
 
 #include "DeathNoticeContext.h"
+#include <Utils/StringBuilder.h>
 
 template <typename HookContext, typename Context = DeathNoticeContext<HookContext>>
 class DeathNotice {

--- a/Source/GameClasses/Hud/HudContext.h
+++ b/Source/GameClasses/Hud/HudContext.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <GameClasses/PanelHandle.h>
+#include <MemoryPatterns/PatternTypes/ClientPatternTypes.h>
 
 template <typename HookContext>
 struct HudContext {

--- a/Source/GameClasses/PanelFactory.h
+++ b/Source/GameClasses/PanelFactory.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <GameClasses/PanoramaImagePanel.h>
+#include <CS2/Panorama/CLabel.h>
+#include <MemoryPatterns/PatternTypes/PanoramaImagePanelPatternTypes.h>
+#include <MemoryPatterns/PatternTypes/PanelPatternTypes.h>
+#include <MemoryPatterns/PatternTypes/PanoramaLabelPatternTypes.h>
 
 template <typename HookContext>
 struct PanelFactory {

--- a/Source/GameClasses/PanelHandle.h
+++ b/Source/GameClasses/PanelHandle.h
@@ -2,6 +2,7 @@
 
 #include <CS2/Panorama/PanelHandle.h>
 #include <Utils/Lvalue.h>
+#include <GameClasses/PanoramaUiEngine.h>
 
 #include <utility>
 

--- a/Source/GameClasses/PanoramaLabel.h
+++ b/Source/GameClasses/PanoramaLabel.h
@@ -2,6 +2,8 @@
 
 #include <CS2/Panorama/CLabel.h>
 #include <MemoryPatterns/PatternTypes/PanoramaLabelPatternTypes.h>
+#include <MemoryPatterns/PatternTypes/UiPanelPatternTypes.h>
+#include <GameClasses/PanoramaUiPanel.h>
 
 template <typename HookContext>
 struct PanoramaLabel {

--- a/Source/GameClasses/PanoramaUiPanelContext.h
+++ b/Source/GameClasses/PanoramaUiPanelContext.h
@@ -9,6 +9,9 @@
 #include "PanoramaUiPanelMethodInvoker.h"
 #include <MemoryPatterns/PatternTypes/PanelStylePatternTypes.h>
 #include <MemoryPatterns/PatternTypes/UiPanelPatternTypes.h>
+#include <CS2/Constants/ColorConstants.h>
+#include <GameClasses/TopLevelWindow.h>
+#include <FeatureHelpers/PanelStylePropertyFactory.h>
 
 template <typename HookContext>
 struct PanoramaUiPanelContext {

--- a/Source/GameClasses/SceneObjectAttributes.h
+++ b/Source/GameClasses/SceneObjectAttributes.h
@@ -2,6 +2,8 @@
 
 #include <CS2/Classes/CSceneObject.h>
 #include <MemoryPatterns/PatternTypes/ClientPatternTypes.h>
+#include <CS2/Classes/Color.h>
+#include <cstring>
 
 template <typename HookContext>
 class SceneObjectAttributes {

--- a/Source/GameClasses/SceneObjectUpdater.h
+++ b/Source/GameClasses/SceneObjectUpdater.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <CS2/Classes/SceneObjectUpdaterHandle_t.h>
+#include <GameClasses/SceneObject.h>
+#include <MemoryPatterns/PatternTypes/SceneObjectUpdaterPatternTypes.h>
+
 template <typename HookContext>
 class SceneObjectUpdater {
 public:

--- a/Source/GameClasses/SceneObjectUpdaters.h
+++ b/Source/GameClasses/SceneObjectUpdaters.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "SceneObjectUpdater.h"
+#include <CS2/Classes/CRenderComponent.h>
 
 template <typename HookContext>
 class SceneObjectUpdaters {

--- a/Source/GameClasses/SceneSystem.h
+++ b/Source/GameClasses/SceneSystem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <MemoryPatterns/PatternTypes/SceneSystemPatternTypes.h>
+
 template <typename HookContext>
 class SceneSystem {
 public:

--- a/Source/GlobalContext/GlobalContext.h
+++ b/Source/GlobalContext/GlobalContext.h
@@ -16,6 +16,7 @@
 #include "FullGlobalContext.h"
 #include "PartialGlobalContext.h"
 #include "HookDependencies/HookDependencies.h"
+#include <Utils/ManuallyDestructible.h>
 
 class GlobalContext {
 public:

--- a/Source/MemoryAllocation/FreeMemoryRegion.h
+++ b/Source/MemoryAllocation/FreeMemoryRegion.h
@@ -2,7 +2,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <cstdint>
 #include <functional>
 #include <span>
 

--- a/Source/MemorySearch/BytePatternConverter.h
+++ b/Source/MemorySearch/BytePatternConverter.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cassert>
 #include <string_view>
 #include <utility>
 

--- a/Source/OutlineGlow/GlowSceneObjectContext.h
+++ b/Source/OutlineGlow/GlowSceneObjectContext.h
@@ -4,6 +4,8 @@
 #include <CS2/Classes/Color.h>
 #include <GameClasses/SceneObject.h>
 #include <Platform/Macros/IsPlatform.h>
+#include <MemoryPatterns/Linux/GlowSceneObjectPatternsLinux.h>
+#include <cstring>
 
 #include "GlowSceneObjectPointer.h"
 

--- a/Source/OutlineGlow/GlowSceneObjectPointer.h
+++ b/Source/OutlineGlow/GlowSceneObjectPointer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <CS2/Classes/Glow.h>
 
 class GlowSceneObjectPointer {

--- a/Source/UI/Panorama/VisualsTab.h
+++ b/Source/UI/Panorama/VisualsTab.h
@@ -2,6 +2,8 @@
 
 #include <GameClasses/PanoramaDropDown.h>
 #include <Platform/Macros/FunctionAttributes.h>
+#include <Features/Visuals/PlayerInfoInWorld/PlayerStateIcons/PlayerStateIconsToShow.h>
+#include <Features/Visuals/ModelGlow/ModelGlowState.h>
 
 template <typename HookContext>
 class VisualsTab {

--- a/Source/Utils/MemorySection.h
+++ b/Source/Utils/MemorySection.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cassert>
 #include <span>
 
 struct MemorySection {

--- a/Source/Utils/TypeList.h
+++ b/Source/Utils/TypeList.h
@@ -4,6 +4,7 @@
 
 #include "Meta.h"
 #include "TypeIndex.h"
+#include <algorithm>
 
 template <typename... Types>
 struct TypeList {


### PR DESCRIPTION
Added explicit includes for all necessary dependencies in header files to resolve issues caused by unity builds interfering with LSP functionality. This ensures better code clarity and maintainability. Also removed some useless imports. Project still builds and works on linux, windows has not been tested.