### PR TITLE
Add download links for binaries built by Github Actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,6 +65,11 @@ jobs:
       run: CXX=${{ matrix.compiler }} cmake -Werror=dev -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DENABLE_TESTS="unit;functional" -DCMAKE_COMPILE_WARNING_AS_ERROR=1 -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=4 -B build
     - name: build source
       run: cmake --build build --target Osiris -j $(nproc --all)
+    - name: upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Osiris_${{ matrix.os }}_cmake_${{ matrix.compiler }}_${{ matrix.configuration }}
+        path: build/Source/libOsiris.so
     - name: build unit tests
       run: cmake --build build --target UnitTests -j $(nproc --all)
     - name: build functional tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,6 +78,11 @@ jobs:
       run: CXX=${{ matrix.compiler }} cmake -Werror=dev -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DENABLE_TESTS="unit;functional" -DCMAKE_COMPILE_WARNING_AS_ERROR=1 -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=4 -B build
     - name: build source
       run: cmake --build build --target Osiris -j $(nproc --all)
+    - name: upload artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: Osiris_${{ matrix.os }}_cmake_${{ matrix.compiler }}_${{ matrix.configuration }}
+        path: build/Source/libOsiris.so
     - name: build unit tests
       run: cmake --build build --target UnitTests -j $(nproc --all)
     - name: build functional tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,11 @@ jobs:
     - name: Build
       shell: cmd
       run: msbuild Osiris.sln /p:Platform=x64 /p:Configuration=${{ matrix.configuration }} ${{ env.toolset }}
+    - name: upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Osiris_${{ matrix.os }}_msbuild_${{ matrix.toolset }}_${{ matrix.configuration }}
+        path: x64\${{ matrix.configuration }}\Osiris.dll
 
   cmake:
     runs-on: ${{ matrix.os }}
@@ -37,6 +42,11 @@ jobs:
       run: cmake -Werror=dev -D ENABLE_TESTS="unit;functional" -D CMAKE_COMPILE_WARNING_AS_ERROR=1 -A x64 ${{ env.toolset }} -B build
     - name: build source
       run: cmake --build build --target Osiris --config ${{ matrix.configuration }}
+    - name: upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Osiris_${{ matrix.os }}_cmake_${{ matrix.toolset }}_${{ matrix.configuration }}
+        path: build\Source\${{ matrix.configuration }}\Osiris.dll
     - name: build unit tests
       run: cmake --build build --target UnitTests --config ${{ matrix.configuration }}
     - name: build functional tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,11 @@ jobs:
     - name: Build
       shell: cmd
       run: msbuild Osiris.sln /p:Platform=x64 /p:Configuration=${{ matrix.configuration }} ${{ env.toolset }}
+    - name: upload artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: Osiris_${{ matrix.os }}_msbuild_${{ matrix.toolset }}_${{ matrix.configuration }}
+        path: x64\${{ matrix.configuration }}\Osiris.dll
 
   cmake:
     runs-on: ${{ matrix.os }}
@@ -37,6 +42,11 @@ jobs:
       run: cmake -Werror=dev -D ENABLE_TESTS="unit;functional" -D CMAKE_COMPILE_WARNING_AS_ERROR=1 -A x64 ${{ env.toolset }} -B build
     - name: build source
       run: cmake --build build --target Osiris --config ${{ matrix.configuration }}
+    - name: upload artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: Osiris_${{ matrix.os }}_cmake_${{ matrix.toolset }}_${{ matrix.configuration }}
+        path: build\Source\${{ matrix.configuration }}\Osiris.dll
     - name: build unit tests
       run: cmake --build build --target UnitTests --config ${{ matrix.configuration }}
     - name: build functional tests

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Cross-platform (Windows, Linux) game hack for **Counter-Strike 2** with GUI and 
 * Exceptions are not used
 * No external dependencies
 
+## Downloading pre-built binaries
+
+* [Latest MSVC build for Windows](https://nightly.link/danielkrupinski/Osiris/workflows/windows/master/Osiris_windows-2025_msbuild_MSVC_Release.zip)
+* [Latest g++ build for Linux](https://nightly.link/danielkrupinski/Osiris/workflows/linux/master/Osiris_ubuntu-24.04_cmake_g%2B%2B-15_Release.zip)
+
 ## Compiling
 
 ### Prerequisites
@@ -70,9 +75,9 @@ Build:
 
 After following these steps you should receive **libOsiris.so** file in **build/Source/** directory.
 
-### Loading / Injecting into game process
+## Loading / Injecting into game process
 
-#### Windows
+### Windows
 
 You need a **DLL injector** to inject (load) **Osiris.dll** into game process.
 
@@ -80,7 +85,7 @@ Counter-Strike 2 blocks LoadLibrary injection method, so you have to use a manua
 
 **Xenos** and **Extreme Injector** are known to be **detected** by VAC.
 
-#### Linux
+### Linux
 
 You can simply run the following script in the directory containing **libOsiris.so**:
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Cross-platform (Windows, Linux) game hack for **Counter-Strike 2** with GUI and 
 * Exceptions are not used
 * No external dependencies
 
+## Downloading pre-built binaries
+
+* [Latest MSVC build for Windows](https://nightly.link/danielkrupinski/Osiris/workflows/windows/master/Osiris_windows-2025_msbuild_MSVC_Release.zip)
+* [Latest g++ build for Linux](https://nightly.link/danielkrupinski/Osiris/workflows/linux/master/Osiris_ubuntu-24.04_cmake_g%2B%2B-16_Release.zip)
+
 ## Compiling
 
 ### Prerequisites
@@ -70,9 +75,9 @@ Build:
 
 After following these steps you should receive **libOsiris.so** file in **build/Source/** directory.
 
-### Loading / Injecting into game process
+## Loading / Injecting into game process
 
-#### Windows
+### Windows
 
 You need a **DLL injector** to inject (load) **Osiris.dll** into game process.
 
@@ -80,7 +85,7 @@ Counter-Strike 2 blocks LoadLibrary injection method, so you have to use a manua
 
 **Xenos** and **Extreme Injector** are known to be **detected** by VAC.
 
-#### Linux
+### Linux
 
 You can simply run the following script in the directory containing **libOsiris.so**:
 


### PR DESCRIPTION
Having to:

1. Download Visual Studio
2. Clone the repo
3. Build the dll

to use Osiris is inconvenient. This PR adds:
- Automatic artifact uploads from Github Actions builds
- Links to the latest build for Windows and Linux in the README.md via [nightly.link](https://nightly.link/).